### PR TITLE
Added TLS support for sip providers

### DIFF
--- a/mod/registry/sip_provider.js
+++ b/mod/registry/sip_provider.js
@@ -19,8 +19,10 @@ module.exports = (properties, bindAddr = defBindAddr(), port = defPort()) => {
 
   const sipStack = sipFactory.createSipStack(properties)
   const lpTCP = sipStack.createListeningPoint(bindAddr, port, 'tcp')
+  const lpTLS = sipStack.createListeningPoint(bindAddr, port + 1, 'tls')
   const lpUDP = sipStack.createListeningPoint(bindAddr, port, 'udp')
   const sipProvider = sipStack.createSipProvider(lpTCP)
+  sipProvider.addListeningPoint(lpTLS)
   sipProvider.addListeningPoint(lpUDP)
 
   return sipProvider


### PR DESCRIPTION
We noticed that gateways only support UDP and TCP connections.

We have adapted sip_provider.js in such a way that TLS connections are now also possible. The port selected for this is the successor to the TCP / UDP port.

The adaptation is covered by the it-test 'Create sip provider' in core/registry/test.js. The test works independently of the selected protocol (TCP, UDP, TLS).