### PR TITLE
Add ability to override apiserver's init container resources requests and limits

### DIFF
--- a/ops/charts/connect/Chart.yaml
+++ b/ops/charts/connect/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: routr-connect
 description: Routr Connect Helm Chart
 type: application
-version: 0.3.0
+version: 0.4.0
 appVersion: 2.3.1
 dependencies:
   - name: postgresql

--- a/ops/charts/connect/README.md
+++ b/ops/charts/connect/README.md
@@ -75,55 +75,55 @@ The [CHANGELOG](https://github.com/fonoster/routr/tree/gh-pages/charts/CHANGELOG
 
 ### Edgeport parameters
 
-| Parameter                                             | Description                                                                                                   | Value                                                       |
-| ----------------------------------------------------- | ------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------- |
-| `edgeport.externalAddrs`                              | The set of addresses at the edge of the network required to correctly route SIP messages                      | `[]`                                                        |
-| `edgeport.localnets`                                  | The set of local networks that are considered "local" (Defaults to the local networks as reported by the OS)  |                                                             |
-| `edgeport.methods`                                    | Acceptable SIP methods. Methods not in the list will be treated according with `edgeport.unknownMethodAction` | `["REGISTER", "MESSAGE", "INVITE", "ACK", "BYE", "CANCEL"]` |
-| `edgeport.unknownMethodAction`                        | Action upon receiving an unsupported SIP method (Reserved for future use)                                     | `Discard`                                                   |
-| `edgeport.heplifyOptions`                             | If set, the server will send SIP messages to Homer (e.g. `homerserver:9060`)                                  | `""`                                                        |
-| `edgeport.pkcs12Password`                             | The password for JAIN SIP security context (Please change the password for production environments)           | `changeme`                                                  |
-| `edgeport.transport`                                  | Transport configuration section                                                                               |                                                             |
-| `edgeport.transport.tcp.enabled`                      | Enable or disable the TCP transport                                                                           | `false`                                                     |
-| `edgeport.transport.tcp.port`                         | Port to listen on                                                                                             | `5060`                                                      |
-| `edgeport.transport.udp.enabled`                      | Enable or disable the UDP transport                                                                           | `true`                                                      |
-| `edgeport.transport.udp.port`                         | Port to listen on                                                                                             | `5060`                                                      |
-| `edgeport.transport.tls.enabled`                      | Enable or disable the TLS transport                                                                           | `false`                                                     |
-| `edgeport.transport.tls.port`                         | Port to listen on                                                                                             | `5061`                                                      |
-| `edgeport.transport.ws.enabled`                       | Enable or disable the WS transport                                                                            | `false`                                                     |
-| `edgeport.transport.ws.port`                          | Port to listen on                                                                                             | `5062`                                                      |
-| `edgeport.transport.wss.enabled`                      | Enable or disable the WSS transport                                                                           | `false`                                                     |
-| `edgeport.transport.wss.port`                         | Port to listen on                                                                                             | `5063`                                                      |
-| `edgeport.udpHealthCheck`                             | Enable or disable the UDP health check                                                                        | `false`                                                     |
-| `edgeport.image.repository`                           | Image repository                                                                                              | `fonoster/routr-edgeport`                                   |
-| `edgeport.image.tag`                                  | Image tag                                                                                                     | `{{ .Chart.AppVersion }}`                                   |
-| `edgeport.image.pullPolicy`                           | Image pull policy                                                                                             | `IfNotPresent`                                              |
-| `edgeport.podAnnotations`                             | Pod annotations                                                                                               | `{}`                                                        |
-| `edgeport.serviceAnnotationsTCP`                      | Service annotations for TCP protocols                                                                         | `{}`                                                        |
-| `edgeport.serviceAnnotationsUDP`                      | Service annotations for UDP protocols                                                                         | `{}`                                                        |
-| `edgeport.replicas`                                   | Maximum number of replicas                                                                                    | `2`                                                         |
-| `edgeport.securityContext.runAsUser`                  | Running as a non-root user                                                                                    | `1000`                                                      |
-| `edgeport.securityContext.runAsGroup`                 | Running as non-root group                                                                                     | `3000`                                                      |
-| `edgeport.securityContext.fsGroup`                    | File system group                                                                                             | `2000`                                                      |
-| `edgeport.securityContext.allowPrivilegeEscalation`   | By default, no privilege escalation is allowed                                                                | `false`                                                     |
-| `edgeport.livenessProbe.initialDelaySeconds`          | Initial delay in seconds before starting the liveness probe                                                   | `10`                                                        |
-| `edgeport.livenessProbe.periodSeconds`                | Period between liveness probes                                                                                | `5`                                                         |
-| `edgeport.livenessProbe.successThreshold`             | Number of successes required to be considered healthy                                                         | `1`                                                         |
-| `edgeport.livenessProbe.failureThreshold`             | Number of failures required to be considered unhealthy                                                        | `2`                                                         |
-| `edgeport.livenessProbe.timeoutSeconds`               | Timeout in seconds for liveness probe                                                                         | `1`                                                         |
-| `edgeport.externalTrafficPolicyTCP`                   | Denotes if this Service desires to route external traffic to node-local or cluster-wide endpoints (TCP)       | `Cluster`                                                   |
-| `edgeport.externalTrafficPolicyUDP`                   | Denotes if this Service desires to route external traffic to node-local or cluster-wide endpoints (UDP)       | `Cluster`                                                   |
-| `edgeport.serviceTypeTCP`                             | The type for the service for TCP                                                                              | `NodePort`                                                  |
-| `edgeport.serviceTypeUDP`                             | The type for the service for UDP                                                                              | `NodePort`                                                  |
-| `edgeport.terminationGracePeriodSeconds`              | Maximum time for the pod to be ready before being killed                                                      | `10`                                                        |
-| `edgeport.resources.requests`                         | Resource requests (e.g. `{"memory": "256Mi", "cpu": "100m"}`)                                                 | `{}`                                                        |
-| `edgeport.resources.limits`                           | Resource limits (e.g. `{"memory": "512Mi", "cpu": "200m"}`)                                                   | `{}`                                                        |
+| Parameter                                           | Description                                                                                                   | Value                                                       |
+| --------------------------------------------------- | ------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------- |
+| `edgeport.externalAddrs`                            | The set of addresses at the edge of the network required to correctly route SIP messages                      | `[]`                                                        |
+| `edgeport.localnets`                                | The set of local networks that are considered "local" (Defaults to the local networks as reported by the OS)  |                                                             |
+| `edgeport.methods`                                  | Acceptable SIP methods. Methods not in the list will be treated according with `edgeport.unknownMethodAction` | `["REGISTER", "MESSAGE", "INVITE", "ACK", "BYE", "CANCEL"]` |
+| `edgeport.unknownMethodAction`                      | Action upon receiving an unsupported SIP method (Reserved for future use)                                     | `Discard`                                                   |
+| `edgeport.heplifyOptions`                           | If set, the server will send SIP messages to Homer (e.g. `homerserver:9060`)                                  | `""`                                                        |
+| `edgeport.pkcs12Password`                           | The password for JAIN SIP security context (Please change the password for production environments)           | `changeme`                                                  |
+| `edgeport.transport`                                | Transport configuration section                                                                               |                                                             |
+| `edgeport.transport.tcp.enabled`                    | Enable or disable the TCP transport                                                                           | `false`                                                     |
+| `edgeport.transport.tcp.port`                       | Port to listen on                                                                                             | `5060`                                                      |
+| `edgeport.transport.udp.enabled`                    | Enable or disable the UDP transport                                                                           | `true`                                                      |
+| `edgeport.transport.udp.port`                       | Port to listen on                                                                                             | `5060`                                                      |
+| `edgeport.transport.tls.enabled`                    | Enable or disable the TLS transport                                                                           | `false`                                                     |
+| `edgeport.transport.tls.port`                       | Port to listen on                                                                                             | `5061`                                                      |
+| `edgeport.transport.ws.enabled`                     | Enable or disable the WS transport                                                                            | `false`                                                     |
+| `edgeport.transport.ws.port`                        | Port to listen on                                                                                             | `5062`                                                      |
+| `edgeport.transport.wss.enabled`                    | Enable or disable the WSS transport                                                                           | `false`                                                     |
+| `edgeport.transport.wss.port`                       | Port to listen on                                                                                             | `5063`                                                      |
+| `edgeport.udpHealthCheck`                           | Enable or disable the UDP health check                                                                        | `false`                                                     |
+| `edgeport.image.repository`                         | Image repository                                                                                              | `fonoster/routr-edgeport`                                   |
+| `edgeport.image.tag`                                | Image tag                                                                                                     | `{{ .Chart.AppVersion }}`                                   |
+| `edgeport.image.pullPolicy`                         | Image pull policy                                                                                             | `IfNotPresent`                                              |
+| `edgeport.podAnnotations`                           | Pod annotations                                                                                               | `{}`                                                        |
+| `edgeport.serviceAnnotationsTCP`                    | Service annotations for TCP protocols                                                                         | `{}`                                                        |
+| `edgeport.serviceAnnotationsUDP`                    | Service annotations for UDP protocols                                                                         | `{}`                                                        |
+| `edgeport.replicas`                                 | Maximum number of replicas                                                                                    | `2`                                                         |
+| `edgeport.securityContext.runAsUser`                | Running as a non-root user                                                                                    | `1000`                                                      |
+| `edgeport.securityContext.runAsGroup`               | Running as non-root group                                                                                     | `3000`                                                      |
+| `edgeport.securityContext.fsGroup`                  | File system group                                                                                             | `2000`                                                      |
+| `edgeport.securityContext.allowPrivilegeEscalation` | By default, no privilege escalation is allowed                                                                | `false`                                                     |
+| `edgeport.livenessProbe.initialDelaySeconds`        | Initial delay in seconds before starting the liveness probe                                                   | `10`                                                        |
+| `edgeport.livenessProbe.periodSeconds`              | Period between liveness probes                                                                                | `5`                                                         |
+| `edgeport.livenessProbe.successThreshold`           | Number of successes required to be considered healthy                                                         | `1`                                                         |
+| `edgeport.livenessProbe.failureThreshold`           | Number of failures required to be considered unhealthy                                                        | `2`                                                         |
+| `edgeport.livenessProbe.timeoutSeconds`             | Timeout in seconds for liveness probe                                                                         | `1`                                                         |
+| `edgeport.externalTrafficPolicyTCP`                 | Denotes if this Service desires to route external traffic to node-local or cluster-wide endpoints (TCP)       | `Cluster`                                                   |
+| `edgeport.externalTrafficPolicyUDP`                 | Denotes if this Service desires to route external traffic to node-local or cluster-wide endpoints (UDP)       | `Cluster`                                                   |
+| `edgeport.serviceTypeTCP`                           | The type for the service for TCP                                                                              | `NodePort`                                                  |
+| `edgeport.serviceTypeUDP`                           | The type for the service for UDP                                                                              | `NodePort`                                                  |
+| `edgeport.terminationGracePeriodSeconds`            | Maximum time for the pod to be ready before being killed                                                      | `10`                                                        |
+| `edgeport.resources.requests`                       | Resource requests (e.g. `{"memory": "256Mi", "cpu": "100m"}`)                                                 | `{}`                                                        |
+| `edgeport.resources.limits`                         | Resource limits (e.g. `{"memory": "512Mi", "cpu": "200m"}`)                                                   | `{}`                                                        |
 
 ### Dispatcher parameters
 
 | Parameter                                                  | Description                                                   | Value                                                       |
 | ---------------------------------------------------------- | ------------------------------------------------------------- | ----------------------------------------------------------- |
-| `dispatcher.processors`                                    | Processors configuration section                              |                                                             |                    
+| `dispatcher.processors`                                    | Processors configuration section                              |                                                             |
 | `dispatcher.processors[*].ref`                             | Reference to the Processor                                    | `connect-processor`                                         |
 | `dispatcher.processors[*].servicePrefix`                   | Prefix for the service (Defaults to the release name)         | `{{ .Release.Name }}`                                       |
 | `dispatcher.processors[*].serviceName`                     | The name of the service hosting the processor                 | `{{ .serviceName }}`                                        |
@@ -187,87 +187,86 @@ The [CHANGELOG](https://github.com/fonoster/routr/tree/gh-pages/charts/CHANGELOG
 
 ### APIServer parameters
 
-| Parameter                                                     | Description                                                                                   | Value                              |
-| ------------------------------------------------------------- | --------------------------------------------------------------------------------------------- | ---------------------------------- |
-| `apiserver.image.repository`                                  | Image repository                                                                              | `fonoster/routr-pgdata`            |
-| `apiserver.image.tag`                                         | Image tag                                                                                     | `{{ .Chart.AppVersion }}`          |
-| `apiserver.image.pullPolicy`                                  | Image pull policy                                                                             | `IfNotPresent`                     |
-| `apiserver.migrationsEnabled`                                 | Enables database migrations                                                                   | `true`                             |
-| `apiserver.migrationsImage.repository`                        | Image repository                                                                              | `fonoster/routr-pgdata-migrations` |
-| `apiserver.migrationsImage.tag`                               | Image tag                                                                                     | `{{ .Chart.AppVersion }}`          |
-| `apiserver.migrationsImage.pullPolicy`                        | Image pull policy                                                                             | `IfNotPresent`                     |
-| `apiserver.tlsOn`                                             | Enables TLS for the APIServer                                                                 | `true`                             |
-| `apiserver.verifyClientCert`                                  | To verify the client's certificate during authentication                                      | `false`                            |
-| `apiserver.podAnnotations`                                    | Pod annotations                                                                               | `{}`                               |
-| `apiserver.serviceAnnotations`                                | Service annotations                                                                           | `{}`                               |
-| `apiserver.autoscaling.miniReplicas`                          | Minimum number of replicas                                                                    | `1`                                |
-| `apiserver.autoscaling.maxReplicas`                           | Maximum number of replicas                                                                    | `10`                               |
-| `apiserver.autoscaling.targetCPUUtilizationPercentage`        | Target CPU utilization percentage                                                             | `50`                               |
-| `apiserver.autoscaling.targetMemoryUtilizationPercentage`     | Target Memory utilization percentage                                                          | `70`                               |
-| `apiserver.securityContext.runAsUser`                         | Running as a non-root user                                                                    | `1000`                             |
-| `apiserver.securityContext.runAsGroup`                        | Running as non-root group                                                                     | `3000`                             |
-| `apiserver.securityContext.fsGroup`                           | File system group                                                                             | `2000`                             |
-| `apiserver.securityContext.allowPrivilegeEscalation`          | By default, no privilege escalation is allowed                                                | `false`                            |
-| `apiserver.livenessProbe.initialDelaySeconds`                 | Initial delay in seconds before starting the liveness probe                                   | `5`                                |
-| `apiserver.livenessProbe.periodSeconds`                       | Period between liveness probes                                                                | `5`                                |
-| `apiserver.livenessProbe.successThreshold`                    | Number of successes required to be considered healthy                                         | `1`                                |
-| `apiserver.livenessProbe.failureThreshold`                    | Number of failures required to be considered unhealthy                                        | `2`                                |
-| `apiserver.livenessProbe.timeoutSeconds`                      | Timeout in seconds for liveness probe                                                         | `1`                                |
-| `apiserver.resources.requests`                                | Resource requests (e.g. `{"memory": "256Mi", "cpu": "100m"}`)                                 | `{}`                               |
-| `apiserver.resources.limits`                                  | Resource limits (e.g. `{"memory": "512Mi", "cpu": "200m"}`)                                   | `{}`                               |
-| `apiserver.initContainers.waitForDatabase.resources.limits`   | Resource limits for `wait-for-db` initContainer (e.g. `{"memory": "512Mi", "cpu": "200m"}`)   | `{}`                               |
-| `apiserver.initContainers.waitForDatabase.resources.requests` | Resource requests for `wait-for-db` initContainer (e.g. `{"memory": "512Mi", "cpu": "200m"}`) | `{}`                               |
-
+| Parameter                                                 | Description                                                             | Value                              |
+| --------------------------------------------------------- | ----------------------------------------------------------------------- | ---------------------------------- |
+| `apiserver.image.repository`                              | Image repository                                                        | `fonoster/routr-pgdata`            |
+| `apiserver.image.tag`                                     | Image tag                                                               | `{{ .Chart.AppVersion }}`          |
+| `apiserver.image.pullPolicy`                              | Image pull policy                                                       | `IfNotPresent`                     |
+| `apiserver.migrations.enabled`                            | Enables database migrations                                             | `true`                             |
+| `apiserver.migrations.image.repository`                   | Migration image repository                                              | `fonoster/routr-pgdata-migrations` |
+| `apiserver.migrations.image.tag`                          | Migration image tag                                                     | `{{ .Chart.AppVersion }}`          |
+| `apiserver.migrations.image.pullPolicy`                   | Migration image pull policy                                             | `IfNotPresent`                     |
+| `apiserver.migrations.resources.limits`                   | Migration resource limits (e.g. `{"memory": "256Mi", "cpu": "100m"}`)   | `{}`                               |
+| `apiserver.migrations.resources.requests`                 | Migration resource requests (e.g. `{"memory": "256Mi", "cpu": "100m"}`) | `{}`                               |
+| `apiserver.tlsOn`                                         | Enables TLS for the APIServer                                           | `true`                             |
+| `apiserver.verifyClientCert`                              | To verify the client's certificate during authentication                | `false`                            |
+| `apiserver.podAnnotations`                                | Pod annotations                                                         | `{}`                               |
+| `apiserver.serviceAnnotations`                            | Service annotations                                                     | `{}`                               |
+| `apiserver.autoscaling.miniReplicas`                      | Minimum number of replicas                                              | `1`                                |
+| `apiserver.autoscaling.maxReplicas`                       | Maximum number of replicas                                              | `10`                               |
+| `apiserver.autoscaling.targetCPUUtilizationPercentage`    | Target CPU utilization percentage                                       | `50`                               |
+| `apiserver.autoscaling.targetMemoryUtilizationPercentage` | Target Memory utilization percentage                                    | `70`                               |
+| `apiserver.securityContext.runAsUser`                     | Running as a non-root user                                              | `1000`                             |
+| `apiserver.securityContext.runAsGroup`                    | Running as non-root group                                               | `3000`                             |
+| `apiserver.securityContext.fsGroup`                       | File system group                                                       | `2000`                             |
+| `apiserver.securityContext.allowPrivilegeEscalation`      | By default, no privilege escalation is allowed                          | `false`                            |
+| `apiserver.livenessProbe.initialDelaySeconds`             | Initial delay in seconds before starting the liveness probe             | `5`                                |
+| `apiserver.livenessProbe.periodSeconds`                   | Period between liveness probes                                          | `5`                                |
+| `apiserver.livenessProbe.successThreshold`                | Number of successes required to be considered healthy                   | `1`                                |
+| `apiserver.livenessProbe.failureThreshold`                | Number of failures required to be considered unhealthy                  | `2`                                |
+| `apiserver.livenessProbe.timeoutSeconds`                  | Timeout in seconds for liveness probe                                   | `1`                                |
+| `apiserver.resources.requests`                            | Resource requests (e.g. `{"memory": "256Mi", "cpu": "100m"}`)           | `{}`                               |
+| `apiserver.resources.limits`                              | Resource limits (e.g. `{"memory": "512Mi", "cpu": "200m"}`)             | `{}`                               |
 
 ### Connect Processor parameters
 
-| Parameter                                               | Description                                                   | Value                    |
-| ------------------------------------------------------- | ------------------------------------------------------------- | ------------------------ |
-| `connect.image.repository`                              | Image repository                                              | `fonoster/routr-connect` |
-| `connect.image.tag`                                     | Image tag                                                     | `{{ .Chart.AppVersion }}`|
-| `connect.image.pullPolicy`                              | Image pull policy                                             | `IfNotPresent`           |
-| `connect.podAnnotations`                                | Pod annotations                                               | `{}`                     |
-| `connect.serviceAnnotations`                            | Service annotations                                           | `{}`                     |
-| `connect.autoscaling.miniReplicas`                      | Minimum number of replicas                                    | `1`                      |
-| `connect.autoscaling.maxReplicas`                       | Maximum number of replicas                                    | `10`                     |
-| `connect.autoscaling.targetCPUUtilizationPercentage`    | Target CPU utilization percentage                             | `50`                     |
-| `connect.autoscaling.targetMemoryUtilizationPercentage` | Target Memory utilization percentage                          | `70`                     |
-| `connect.securityContext.runAsUser`                     | Running as a non-root user                                    | `1000`                   |
-| `connect.securityContext.runAsGroup`                    | Running as non-root group                                     | `3000`                   |
-| `connect.securityContext.fsGroup`                       | File system group                                             | `2000`                   |
-| `connect.securityContext.allowPrivilegeEscalation`      | By default, no privilege escalation is allowed                | `false`                  |
-| `connect.livenessProbe.initialDelaySeconds`             | Initial delay in seconds before starting the liveness probe   | `5`                      |
-| `connect.livenessProbe.periodSeconds`                   | Period between liveness probes                                | `5`                      |
-| `connect.livenessProbe.successThreshold`                | Number of successes required to be considered healthy         | `1`                      |
-| `connect.livenessProbe.failureThreshold`                | Number of failures required to be considered unhealthy        | `2`                      |
-| `connect.livenessProbe.timeoutSeconds`                  | Timeout in seconds for liveness probe                         | `1`                      |
-| `connect.resources.requests`                            | Resource requests (e.g. `{"memory": "256Mi", "cpu": "100m"}`) | `{}`                     |
-| `connect.resources.limits`                              | Resource limits (e.g. `{"memory": "512Mi", "cpu": "200m"}`)   | `{}`                     |
+| Parameter                                               | Description                                                   | Value                     |
+| ------------------------------------------------------- | ------------------------------------------------------------- | ------------------------- |
+| `connect.image.repository`                              | Image repository                                              | `fonoster/routr-connect`  |
+| `connect.image.tag`                                     | Image tag                                                     | `{{ .Chart.AppVersion }}` |
+| `connect.image.pullPolicy`                              | Image pull policy                                             | `IfNotPresent`            |
+| `connect.podAnnotations`                                | Pod annotations                                               | `{}`                      |
+| `connect.serviceAnnotations`                            | Service annotations                                           | `{}`                      |
+| `connect.autoscaling.miniReplicas`                      | Minimum number of replicas                                    | `1`                       |
+| `connect.autoscaling.maxReplicas`                       | Maximum number of replicas                                    | `10`                      |
+| `connect.autoscaling.targetCPUUtilizationPercentage`    | Target CPU utilization percentage                             | `50`                      |
+| `connect.autoscaling.targetMemoryUtilizationPercentage` | Target Memory utilization percentage                          | `70`                      |
+| `connect.securityContext.runAsUser`                     | Running as a non-root user                                    | `1000`                    |
+| `connect.securityContext.runAsGroup`                    | Running as non-root group                                     | `3000`                    |
+| `connect.securityContext.fsGroup`                       | File system group                                             | `2000`                    |
+| `connect.securityContext.allowPrivilegeEscalation`      | By default, no privilege escalation is allowed                | `false`                   |
+| `connect.livenessProbe.initialDelaySeconds`             | Initial delay in seconds before starting the liveness probe   | `5`                       |
+| `connect.livenessProbe.periodSeconds`                   | Period between liveness probes                                | `5`                       |
+| `connect.livenessProbe.successThreshold`                | Number of successes required to be considered healthy         | `1`                       |
+| `connect.livenessProbe.failureThreshold`                | Number of failures required to be considered unhealthy        | `2`                       |
+| `connect.livenessProbe.timeoutSeconds`                  | Timeout in seconds for liveness probe                         | `1`                       |
+| `connect.resources.requests`                            | Resource requests (e.g. `{"memory": "256Mi", "cpu": "100m"}`) | `{}`                      |
+| `connect.resources.limits`                              | Resource limits (e.g. `{"memory": "512Mi", "cpu": "200m"}`)   | `{}`                      |
 
 ### Registry parameters
 
-| Parameter                                             | Description                                                   | Value                     |
-| ----------------------------------------------------- | ------------------------------------------------------------- | ------------------------- |
-| `registry.registerInterval`                           | Registration interval in seconds                              | `20`                      |
-| `registry.methods`                                    | Registration methods for the Allow header                     | `["INVITE", "MESSAGE"]`   |
-| `registry.cache.provider`                             | Cache Provider (supports for `redis` and `memory` )           | `redis`                   |
-| `registry.cache.parameters`                           | Cache Parameters                                              | `""`                      |
-| `registry.image.repository`                           | Image repository                                              | `fonoster/routr-registry` |
-| `registry.image.tag`                                  | Image tag                                                     | `{{ .Chart.AppVersion }}` |
-| `registry.image.pullPolicy`                           | Image pull policy                                             | `IfNotPresent`            |
-| `registry.podAnnotations`                             | Pod annotations                                               | `{}`                      |
-| `registry.serviceAnnotations`                         | Service annotations                                           | `{}`                      |
-| `registry.securityContext.runAsUser`                  | Running as a non-root user                                    | `1000`                    |
-| `registry.securityContext.runAsGroup`                 | Running as non-root group                                     | `3000`                    |
-| `registry.securityContext.fsGroup`                    | File system group                                             | `2000`                    |
-| `registry.securityContext.allowPrivilegeEscalation`   | By default, no privilege escalation is allowed                | `false`                   |
-| `registry.livenessProbe.initialDelaySeconds`          | Initial delay in seconds before starting the liveness probe   | `5`                       |
-| `registry.livenessProbe.periodSeconds`                | Period between liveness probes                                | `5`                       |
-| `registry.livenessProbe.successThreshold`             | Number of successes required to be considered healthy         | `1`                       |
-| `registry.livenessProbe.failureThreshold`             | Number of failures required to be considered unhealthy        | `2`                       |
-| `registry.livenessProbe.timeoutSeconds`               | Timeout in seconds for liveness probe                         | `1`                       |
-| `registry.resources.requests`                         | Resource requests (e.g. `{"memory": "256Mi", "cpu": "100m"}`) | `{}`                      |
-| `registry.resources.limits`                           | Resource limits (e.g. `{"memory": "512Mi", "cpu": "200m"}`)   | `{}`                      |
+| Parameter                                           | Description                                                   | Value                     |
+| --------------------------------------------------- | ------------------------------------------------------------- | ------------------------- |
+| `registry.registerInterval`                         | Registration interval in seconds                              | `20`                      |
+| `registry.methods`                                  | Registration methods for the Allow header                     | `["INVITE", "MESSAGE"]`   |
+| `registry.cache.provider`                           | Cache Provider (supports for `redis` and `memory` )           | `redis`                   |
+| `registry.cache.parameters`                         | Cache Parameters                                              | `""`                      |
+| `registry.image.repository`                         | Image repository                                              | `fonoster/routr-registry` |
+| `registry.image.tag`                                | Image tag                                                     | `{{ .Chart.AppVersion }}` |
+| `registry.image.pullPolicy`                         | Image pull policy                                             | `IfNotPresent`            |
+| `registry.podAnnotations`                           | Pod annotations                                               | `{}`                      |
+| `registry.serviceAnnotations`                       | Service annotations                                           | `{}`                      |
+| `registry.securityContext.runAsUser`                | Running as a non-root user                                    | `1000`                    |
+| `registry.securityContext.runAsGroup`               | Running as non-root group                                     | `3000`                    |
+| `registry.securityContext.fsGroup`                  | File system group                                             | `2000`                    |
+| `registry.securityContext.allowPrivilegeEscalation` | By default, no privilege escalation is allowed                | `false`                   |
+| `registry.livenessProbe.initialDelaySeconds`        | Initial delay in seconds before starting the liveness probe   | `5`                       |
+| `registry.livenessProbe.periodSeconds`              | Period between liveness probes                                | `5`                       |
+| `registry.livenessProbe.successThreshold`           | Number of successes required to be considered healthy         | `1`                       |
+| `registry.livenessProbe.failureThreshold`           | Number of failures required to be considered unhealthy        | `2`                       |
+| `registry.livenessProbe.timeoutSeconds`             | Timeout in seconds for liveness probe                         | `1`                       |
+| `registry.resources.requests`                       | Resource requests (e.g. `{"memory": "256Mi", "cpu": "100m"}`) | `{}`                      |
+| `registry.resources.limits`                         | Resource limits (e.g. `{"memory": "512Mi", "cpu": "200m"}`)   | `{}`                      |
 
 ### Requester parameters
 

--- a/ops/charts/connect/README.md
+++ b/ops/charts/connect/README.md
@@ -187,34 +187,37 @@ The [CHANGELOG](https://github.com/fonoster/routr/tree/gh-pages/charts/CHANGELOG
 
 ### APIServer parameters
 
-| Parameter                                                 | Description                                                   | Value                               |
-| --------------------------------------------------------- | ------------------------------------------------------------- | ----------------------------------- |
-| `apiserver.image.repository`                              | Image repository                                              | `fonoster/routr-pgdata`             |
-| `apiserver.image.tag`                                     | Image tag                                                     | `{{ .Chart.AppVersion }}`           |
-| `apiserver.image.pullPolicy`                              | Image pull policy                                             | `IfNotPresent`                      |
-| `apiserver.migrationsEnabled`                             | Enables database migrations                                   | `true`                              |
-| `apiserver.migrationsImage.repository`                    | Image repository                                              | `fonoster/routr-pgdata-migrations`  |
-| `apiserver.migrationsImage.tag`                           | Image tag                                                     | `{{ .Chart.AppVersion }}`           |
-| `apiserver.migrationsImage.pullPolicy`                    | Image pull policy                                             | `IfNotPresent`                      |
-| `apiserver.tlsOn`                                         | Enables TLS for the APIServer                                 | `true`                              |
-| `apiserver.verifyClientCert`                              | To verify the client's certificate during authentication      | `false`                             |
-| `apiserver.podAnnotations`                                | Pod annotations                                               | `{}`                                |
-| `apiserver.serviceAnnotations`                            | Service annotations                                           | `{}`                                |
-| `apiserver.autoscaling.miniReplicas`                      | Minimum number of replicas                                    | `1`                                 |
-| `apiserver.autoscaling.maxReplicas`                       | Maximum number of replicas                                    | `10`                                |
-| `apiserver.autoscaling.targetCPUUtilizationPercentage`    | Target CPU utilization percentage                             | `50`                                |
-| `apiserver.autoscaling.targetMemoryUtilizationPercentage` | Target Memory utilization percentage                          | `70`                                |
-| `apiserver.securityContext.runAsUser`                     | Running as a non-root user                                    | `1000`                              |
-| `apiserver.securityContext.runAsGroup`                    | Running as non-root group                                     | `3000`                              |
-| `apiserver.securityContext.fsGroup`                       | File system group                                             | `2000`                              |
-| `apiserver.securityContext.allowPrivilegeEscalation`      | By default, no privilege escalation is allowed                | `false`                             |
-| `apiserver.livenessProbe.initialDelaySeconds`             | Initial delay in seconds before starting the liveness probe   | `5`                                 |
-| `apiserver.livenessProbe.periodSeconds`                   | Period between liveness probes                                | `5`                                 |
-| `apiserver.livenessProbe.successThreshold`                | Number of successes required to be considered healthy         | `1`                                 |
-| `apiserver.livenessProbe.failureThreshold`                | Number of failures required to be considered unhealthy        | `2`                                 |
-| `apiserver.livenessProbe.timeoutSeconds`                  | Timeout in seconds for liveness probe                         | `1`                                 |
-| `apiserver.resources.requests`                            | Resource requests (e.g. `{"memory": "256Mi", "cpu": "100m"}`) | `{}`                                |
-| `apiserver.resources.limits`                              | Resource limits (e.g. `{"memory": "512Mi", "cpu": "200m"}`)   | `{}`                                |
+| Parameter                                                     | Description                                                                                   | Value                              |
+| ------------------------------------------------------------- | --------------------------------------------------------------------------------------------- | ---------------------------------- |
+| `apiserver.image.repository`                                  | Image repository                                                                              | `fonoster/routr-pgdata`            |
+| `apiserver.image.tag`                                         | Image tag                                                                                     | `{{ .Chart.AppVersion }}`          |
+| `apiserver.image.pullPolicy`                                  | Image pull policy                                                                             | `IfNotPresent`                     |
+| `apiserver.migrationsEnabled`                                 | Enables database migrations                                                                   | `true`                             |
+| `apiserver.migrationsImage.repository`                        | Image repository                                                                              | `fonoster/routr-pgdata-migrations` |
+| `apiserver.migrationsImage.tag`                               | Image tag                                                                                     | `{{ .Chart.AppVersion }}`          |
+| `apiserver.migrationsImage.pullPolicy`                        | Image pull policy                                                                             | `IfNotPresent`                     |
+| `apiserver.tlsOn`                                             | Enables TLS for the APIServer                                                                 | `true`                             |
+| `apiserver.verifyClientCert`                                  | To verify the client's certificate during authentication                                      | `false`                            |
+| `apiserver.podAnnotations`                                    | Pod annotations                                                                               | `{}`                               |
+| `apiserver.serviceAnnotations`                                | Service annotations                                                                           | `{}`                               |
+| `apiserver.autoscaling.miniReplicas`                          | Minimum number of replicas                                                                    | `1`                                |
+| `apiserver.autoscaling.maxReplicas`                           | Maximum number of replicas                                                                    | `10`                               |
+| `apiserver.autoscaling.targetCPUUtilizationPercentage`        | Target CPU utilization percentage                                                             | `50`                               |
+| `apiserver.autoscaling.targetMemoryUtilizationPercentage`     | Target Memory utilization percentage                                                          | `70`                               |
+| `apiserver.securityContext.runAsUser`                         | Running as a non-root user                                                                    | `1000`                             |
+| `apiserver.securityContext.runAsGroup`                        | Running as non-root group                                                                     | `3000`                             |
+| `apiserver.securityContext.fsGroup`                           | File system group                                                                             | `2000`                             |
+| `apiserver.securityContext.allowPrivilegeEscalation`          | By default, no privilege escalation is allowed                                                | `false`                            |
+| `apiserver.livenessProbe.initialDelaySeconds`                 | Initial delay in seconds before starting the liveness probe                                   | `5`                                |
+| `apiserver.livenessProbe.periodSeconds`                       | Period between liveness probes                                                                | `5`                                |
+| `apiserver.livenessProbe.successThreshold`                    | Number of successes required to be considered healthy                                         | `1`                                |
+| `apiserver.livenessProbe.failureThreshold`                    | Number of failures required to be considered unhealthy                                        | `2`                                |
+| `apiserver.livenessProbe.timeoutSeconds`                      | Timeout in seconds for liveness probe                                                         | `1`                                |
+| `apiserver.resources.requests`                                | Resource requests (e.g. `{"memory": "256Mi", "cpu": "100m"}`)                                 | `{}`                               |
+| `apiserver.resources.limits`                                  | Resource limits (e.g. `{"memory": "512Mi", "cpu": "200m"}`)                                   | `{}`                               |
+| `apiserver.initContainers.waitForDatabase.resources.limits`   | Resource limits for `wait-for-db` initContainer (e.g. `{"memory": "512Mi", "cpu": "200m"}`)   | `{}`                               |
+| `apiserver.initContainers.waitForDatabase.resources.requests` | Resource requests for `wait-for-db` initContainer (e.g. `{"memory": "512Mi", "cpu": "200m"}`) | `{}`                               |
+
 
 ### Connect Processor parameters
 

--- a/ops/charts/connect/templates/apiserver/deployment.yaml
+++ b/ops/charts/connect/templates/apiserver/deployment.yaml
@@ -28,16 +28,16 @@ spec:
       {{- if .Values.postgresql.enabled }}
       initContainers:
         - name: wait-for-database
-          image: "{{ .Values.apiserver.migrationsImage.repository }}:{{ .Values.apiserver.migrationsImage.tag | default .Chart.AppVersion }}"
-          imagePullPolicy: {{ .Values.apiserver.migrationsImage.pullPolicy }}
+          image: "{{ .Values.apiserver.migrations.image.repository }}:{{ .Values.apiserver.migrations.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.apiserver.migrations.image.pullPolicy }}
           resources:
-            {{- if .Values.apiserver.initContainers.waitForDatabase.resources.requests  }}
+            {{- if .Values.apiserver.migrations.resources.requests  }}
             requests:
-            {{- .Values.apiserver.initContainers.waitForDatabase.resources.requests | toYaml | nindent 14 }}
+            {{- .Values.apiserver.migrations.resources.requests | toYaml | nindent 14 }}
             {{- end }}
-            {{- if .Values.apiserver.initContainers.waitForDatabase.resources.limits }}
+            {{- if .Values.apiserver.migrations.resources.limits }}
             limits:
-            {{- .Values.apiserver.initContainers.waitForDatabase.resources.limits | toYaml | nindent 14 }}
+            {{- .Values.apiserver.migrations.resources.limits | toYaml | nindent 14 }}
             {{- end }}
           command: ["/bin/sh", "-c"]
           args:

--- a/ops/charts/connect/templates/apiserver/deployment.yaml
+++ b/ops/charts/connect/templates/apiserver/deployment.yaml
@@ -31,13 +31,13 @@ spec:
           image: "{{ .Values.apiserver.migrationsImage.repository }}:{{ .Values.apiserver.migrationsImage.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.apiserver.migrationsImage.pullPolicy }}
           resources:
-            {{- if .Values.apiserver.initContainers.waitForDatabase.resources.limits }}
-            limits:
-            {{- .Values.apiserver.initContainers.waitForDatabase.resources.limits | toYaml | nindent 14 }}
-            {{- end }}
             {{- if .Values.apiserver.initContainers.waitForDatabase.resources.requests  }}
             requests:
             {{- .Values.apiserver.initContainers.waitForDatabase.resources.requests | toYaml | nindent 14 }}
+            {{- end }}
+            {{- if .Values.apiserver.initContainers.waitForDatabase.resources.limits }}
+            limits:
+            {{- .Values.apiserver.initContainers.waitForDatabase.resources.limits | toYaml | nindent 14 }}
             {{- end }}
           command: ["/bin/sh", "-c"]
           args:

--- a/ops/charts/connect/templates/apiserver/deployment.yaml
+++ b/ops/charts/connect/templates/apiserver/deployment.yaml
@@ -30,6 +30,15 @@ spec:
         - name: wait-for-database
           image: "{{ .Values.apiserver.migrationsImage.repository }}:{{ .Values.apiserver.migrationsImage.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.apiserver.migrationsImage.pullPolicy }}
+          resources:
+            {{- if .Values.apiserver.initContainers.waitForDatabase.resources.limits }}
+            limits:
+            {{- .Values.apiserver.initContainers.waitForDatabase.resources.limits | toYaml | nindent 14 }}
+            {{- end }}
+            {{- if .Values.apiserver.initContainers.waitForDatabase.resources.requests  }}
+            requests:
+            {{- .Values.apiserver.initContainers.waitForDatabase.resources.requests | toYaml | nindent 14 }}
+            {{- end }}
           command: ["/bin/sh", "-c"]
           args:
             - |

--- a/ops/charts/connect/templates/apiserver/migration.yaml
+++ b/ops/charts/connect/templates/apiserver/migration.yaml
@@ -1,4 +1,4 @@
-{{- if eq .Values.apiserver.migrationsEnabled true }}
+{{- if eq .Values.apiserver.migrations.enabled true }}
 
 apiVersion: v1
 kind: Pod
@@ -12,8 +12,8 @@ spec:
   {{- if .Values.postgresql.enabled }}
   initContainers:
     - name: wait-for-database
-      image: "{{ .Values.apiserver.migrationsImage.repository }}:{{ .Values.apiserver.migrationsImage.tag | default .Chart.AppVersion }}"
-      imagePullPolicy: {{ .Values.apiserver.migrationsImage.pullPolicy }}
+      image: "{{ .Values.apiserver.migrations.image.repository }}:{{ .Values.apiserver.migrations.image.tag | default .Chart.AppVersion }}"
+      imagePullPolicy: {{ .Values.apiserver.migrations.image.pullPolicy }}
       command: ["/bin/sh", "-c"]
       args:
         - |
@@ -24,8 +24,8 @@ spec:
   {{- end }}
   containers:
     - name: migrations
-      image: "{{ .Values.apiserver.migrationsImage.repository }}:{{ .Values.apiserver.migrationsImage.tag | default .Chart.AppVersion }}"
-      imagePullPolicy: {{ .Values.apiserver.migrationsImage.pullPolicy }}
+      image: "{{ .Values.apiserver.migrations.image.repository }}:{{ .Values.apiserver.migrations.image.tag | default .Chart.AppVersion }}"
+      imagePullPolicy: {{ .Values.apiserver.migrations.image.pullPolicy }}
       envFrom:
         - secretRef:
             name: {{ .Release.Name }}-routr-database-url

--- a/ops/charts/connect/values.yaml
+++ b/ops/charts/connect/values.yaml
@@ -247,7 +247,6 @@ location:
 apiserver:
   # Uncomment the next line if you want to point to an external postgresql db
   # databaseUrl: postgresql://routr:changeme@dbserver:5432/routr?schema=public
-
   # Set to false if you want to disable TLS for the APIServer (Not recommended)
   tlsOn: true
   # When set to true the APIServer will require client certificates
@@ -261,15 +260,21 @@ apiserver:
     # tag: latest
     # APIServer image pull policy default to IfNotPresent
     pullPolicy: IfNotPresent
-  migrationsEnabled: true
-  migrationsImage:
-    # APIServer migrations image repository
-    repository: fonoster/routr-pgdata-migrations
-    # APIServer migrations image tag (immutable tags are recommended)
-    # Uncomment to overwrite Chart.appVersion
-    # tag: latest
-    # APIServer image pull policy default to IfNotPresent
-    pullPolicy: IfNotPresent
+  migrations:
+    enabled: true
+    image:
+      # APIServer migrations image repository
+      repository: fonoster/routr-pgdata-migrations
+      # APIServer migrations image tag (immutable tags are recommended)
+      # Uncomment to overwrite Chart.appVersion
+      # tag: latest
+      # APIServer image pull policy default to IfNotPresent
+      pullPolicy: IfNotPresent
+    resources:
+      # Resource limits
+      limits: {}
+      # Resource requests
+      requests: {}
   # Pod annotations
   podAnnotations: {}
   # Service annotations


### PR DESCRIPTION
## Description

Hi, I am not super familiar with helm charts but I had tested the changes I had made and it seems to work.

Note that I did not change the chart version as I dont know if that its safe to change, I can bump it up so let me know 😄 

Closes #231 

## Type of change

<!-- 
  Choose all that apply and delete options that are not relevant.
-->

- [x] (Might be a breaking change) New feature
- [x] This change requires a documentation update

## How Has This Been Tested?

I had deployed the application with helm install on my kind cluster locally (with update values file)

`values.yaml`
![image](https://github.com/fonoster/routr/assets/42358864/137a0c9b-08c8-436a-8a3d-b01c5863ba40)


https://github.com/fonoster/routr/assets/42358864/4b980b6c-e9ad-4c37-8388-9d8ce8165c32

https://github.com/fonoster/routr/assets/42358864/1ff5d224-85cf-4288-a7bb-6f73d2bd5701

## Checklist:

<!-- Please delete options that are not relevant. -->

- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules
