### PR TITLE
Fix/type import issue

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,4 +1,4 @@
 {
   "packages": ["mods/*"],
-  "version": "2.4.1"
+  "version": "2.4.2"
 }

--- a/mods/connect/package-lock.json
+++ b/mods/connect/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@routr/connect",
-  "version": "2.4.1",
+  "version": "2.4.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@routr/connect",
-      "version": "2.4.1",
+      "version": "2.4.2",
       "license": "MIT",
       "dependencies": {
         "@fonoster/logger": "0.3.20",
@@ -19,7 +19,7 @@
         "@opentelemetry/sdk-trace-node": "^1.0.4",
         "@opentelemetry/semantic-conventions": "^1.0.4",
         "@routr/common": "^2.4.1",
-        "@routr/location": "^2.4.1",
+        "@routr/location": "^2.4.2",
         "@routr/processor": "^2.4.1",
         "jsonwebtoken": "^9.0.0"
       },

--- a/mods/connect/package.json
+++ b/mods/connect/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@routr/connect",
-  "version": "2.4.1",
+  "version": "2.4.2",
   "description": "Default processor",
   "author": "Pedro Sanders <psanders@fonoster.com>",
   "homepage": "https://github.com/fonoster/routr#readme",
@@ -29,7 +29,7 @@
     "@opentelemetry/sdk-trace-node": "^1.0.4",
     "@opentelemetry/semantic-conventions": "^1.0.4",
     "@routr/common": "^2.4.1",
-    "@routr/location": "^2.4.1",
+    "@routr/location": "^2.4.2",
     "@routr/processor": "^2.4.1",
     "jsonwebtoken": "^9.0.0"
   },

--- a/mods/connect/src/router.ts
+++ b/mods/connect/src/router.ts
@@ -44,7 +44,7 @@ import { ILocationService } from "@routr/location"
 import { UnsuportedRoutingError } from "./errors"
 import { getLogger } from "@fonoster/logger"
 import { checkAccess } from "./access"
-import { Backend } from "@routr/location/src/types"
+import { Backend } from "@routr/location"
 
 const logger = getLogger({ service: "connect", filePath: __filename })
 const jwtVerifier = getVerifierImpl()

--- a/mods/ctl/README.md
+++ b/mods/ctl/README.md
@@ -19,7 +19,7 @@ $ npm install -g @routr/ctl
 $ rctl COMMAND
 running command...
 $ rctl (--version)
-@routr/ctl/2.4.1 linux-x64 node-v18.18.0
+@routr/ctl/2.4.2 linux-x64 node-v18.18.2
 $ rctl --help [COMMAND]
 USAGE
   $ rctl COMMAND
@@ -95,7 +95,7 @@ EXAMPLES
   Creating ACL US Eeast... b148b4b4-6884-4c06-bb7e-bd098f5fe793
 ```
 
-_See code: [dist/commands/acl/create.ts](https://github.com/fonoster/routr/blob/v2.4.1/mods/ctl/src/commands/acl/create.ts)_
+_See code: [dist/commands/acl/create.ts](https://github.com/fonoster/routr/blob/v2.4.2/mods/ctl/src/commands/acl/create.ts)_
 
 ## `rctl acl delete [REF]`
 
@@ -118,7 +118,7 @@ EXAMPLES
   Deleting item 80181ca6-d4aa-4575-9375-8f72b071111... Done
 ```
 
-_See code: [dist/commands/acl/delete.ts](https://github.com/fonoster/routr/blob/v2.4.1/mods/ctl/src/commands/acl/delete.ts)_
+_See code: [dist/commands/acl/delete.ts](https://github.com/fonoster/routr/blob/v2.4.2/mods/ctl/src/commands/acl/delete.ts)_
 
 ## `rctl acl describe [REF]`
 
@@ -140,7 +140,7 @@ DESCRIPTION
   shows details of an ACL
 ```
 
-_See code: [dist/commands/acl/describe.ts](https://github.com/fonoster/routr/blob/v2.4.1/mods/ctl/src/commands/acl/describe.ts)_
+_See code: [dist/commands/acl/describe.ts](https://github.com/fonoster/routr/blob/v2.4.2/mods/ctl/src/commands/acl/describe.ts)_
 
 ## `rctl acl get [REF]`
 
@@ -169,7 +169,7 @@ EXAMPLES
   9e7a88f0-8390-42f5-a2cb-689583ba9f4f Local Network ACL 0.0.0.0/0 10.0.0.28
 ```
 
-_See code: [dist/commands/acl/get.ts](https://github.com/fonoster/routr/blob/v2.4.1/mods/ctl/src/commands/acl/get.ts)_
+_See code: [dist/commands/acl/get.ts](https://github.com/fonoster/routr/blob/v2.4.2/mods/ctl/src/commands/acl/get.ts)_
 
 ## `rctl acl update REF`
 
@@ -195,7 +195,7 @@ EXAMPLES
   Updating ACL US East... 80181ca6-d4aa-4575-9375-8f72b07d5555
 ```
 
-_See code: [dist/commands/acl/update.ts](https://github.com/fonoster/routr/blob/v2.4.1/mods/ctl/src/commands/acl/update.ts)_
+_See code: [dist/commands/acl/update.ts](https://github.com/fonoster/routr/blob/v2.4.2/mods/ctl/src/commands/acl/update.ts)_
 
 ## `rctl agents create`
 
@@ -218,7 +218,7 @@ EXAMPLES
   Creating Agent Jhon Doe... b148b4b4-6884-4c06-bb7e-bd098f5fe793
 ```
 
-_See code: [dist/commands/agents/create.ts](https://github.com/fonoster/routr/blob/v2.4.1/mods/ctl/src/commands/agents/create.ts)_
+_See code: [dist/commands/agents/create.ts](https://github.com/fonoster/routr/blob/v2.4.2/mods/ctl/src/commands/agents/create.ts)_
 
 ## `rctl agents delete [REF]`
 
@@ -241,7 +241,7 @@ EXAMPLES
   Deleting item 80181ca6-d4aa-4575-9375-8f72b071111... Done
 ```
 
-_See code: [dist/commands/agents/delete.ts](https://github.com/fonoster/routr/blob/v2.4.1/mods/ctl/src/commands/agents/delete.ts)_
+_See code: [dist/commands/agents/delete.ts](https://github.com/fonoster/routr/blob/v2.4.2/mods/ctl/src/commands/agents/delete.ts)_
 
 ## `rctl agents describe [REF]`
 
@@ -263,7 +263,7 @@ DESCRIPTION
   shows details of an Agent
 ```
 
-_See code: [dist/commands/agents/describe.ts](https://github.com/fonoster/routr/blob/v2.4.1/mods/ctl/src/commands/agents/describe.ts)_
+_See code: [dist/commands/agents/describe.ts](https://github.com/fonoster/routr/blob/v2.4.2/mods/ctl/src/commands/agents/describe.ts)_
 
 ## `rctl agents get [REF]`
 
@@ -292,7 +292,7 @@ EXAMPLES
   d31f5fb8-e367-42f7-9884-1a7999f53fe8 John Doe jdoe     sip.local PRIVATE Yes
 ```
 
-_See code: [dist/commands/agents/get.ts](https://github.com/fonoster/routr/blob/v2.4.1/mods/ctl/src/commands/agents/get.ts)_
+_See code: [dist/commands/agents/get.ts](https://github.com/fonoster/routr/blob/v2.4.2/mods/ctl/src/commands/agents/get.ts)_
 
 ## `rctl agents update REF`
 
@@ -318,7 +318,7 @@ EXAMPLES
   Updating Agent John Doe... 80181ca6-d4aa-4575-9375-8f72b07d5555
 ```
 
-_See code: [dist/commands/agents/update.ts](https://github.com/fonoster/routr/blob/v2.4.1/mods/ctl/src/commands/agents/update.ts)_
+_See code: [dist/commands/agents/update.ts](https://github.com/fonoster/routr/blob/v2.4.2/mods/ctl/src/commands/agents/update.ts)_
 
 ## `rctl autocomplete [SHELL]`
 
@@ -370,7 +370,7 @@ EXAMPLES
   Creating Credentials JDoe Access... b148b4b4-6884-4c06-bb7e-bd098f5fe793
 ```
 
-_See code: [dist/commands/credentials/create.ts](https://github.com/fonoster/routr/blob/v2.4.1/mods/ctl/src/commands/credentials/create.ts)_
+_See code: [dist/commands/credentials/create.ts](https://github.com/fonoster/routr/blob/v2.4.2/mods/ctl/src/commands/credentials/create.ts)_
 
 ## `rctl credentials delete [REF]`
 
@@ -393,7 +393,7 @@ EXAMPLES
   Deleting item 80181ca6-d4aa-4575-9375-8f72b071111... Done
 ```
 
-_See code: [dist/commands/credentials/delete.ts](https://github.com/fonoster/routr/blob/v2.4.1/mods/ctl/src/commands/credentials/delete.ts)_
+_See code: [dist/commands/credentials/delete.ts](https://github.com/fonoster/routr/blob/v2.4.2/mods/ctl/src/commands/credentials/delete.ts)_
 
 ## `rctl credentials describe [REF]`
 
@@ -415,7 +415,7 @@ DESCRIPTION
   shows details for a set of Credentials
 ```
 
-_See code: [dist/commands/credentials/describe.ts](https://github.com/fonoster/routr/blob/v2.4.1/mods/ctl/src/commands/credentials/describe.ts)_
+_See code: [dist/commands/credentials/describe.ts](https://github.com/fonoster/routr/blob/v2.4.2/mods/ctl/src/commands/credentials/describe.ts)_
 
 ## `rctl credentials get [REF]`
 
@@ -444,7 +444,7 @@ EXAMPLES
   80181ca6-d4aa-4575-9375-8f72b07d6666 Europe ACL 0.0.0.0/0 10.0.0.25
 ```
 
-_See code: [dist/commands/credentials/get.ts](https://github.com/fonoster/routr/blob/v2.4.1/mods/ctl/src/commands/credentials/get.ts)_
+_See code: [dist/commands/credentials/get.ts](https://github.com/fonoster/routr/blob/v2.4.2/mods/ctl/src/commands/credentials/get.ts)_
 
 ## `rctl credentials update REF`
 
@@ -470,7 +470,7 @@ EXAMPLES
   Updating Credentials JDoe Credentials... 80181ca6-d4aa-4575-9375-8f72b07d5555
 ```
 
-_See code: [dist/commands/credentials/update.ts](https://github.com/fonoster/routr/blob/v2.4.1/mods/ctl/src/commands/credentials/update.ts)_
+_See code: [dist/commands/credentials/update.ts](https://github.com/fonoster/routr/blob/v2.4.2/mods/ctl/src/commands/credentials/update.ts)_
 
 ## `rctl domains create`
 
@@ -493,7 +493,7 @@ EXAMPLES
   Creating Domain Local Domain... b148b4b4-6884-4c06-bb7e-bd098f5fe793
 ```
 
-_See code: [dist/commands/domains/create.ts](https://github.com/fonoster/routr/blob/v2.4.1/mods/ctl/src/commands/domains/create.ts)_
+_See code: [dist/commands/domains/create.ts](https://github.com/fonoster/routr/blob/v2.4.2/mods/ctl/src/commands/domains/create.ts)_
 
 ## `rctl domains delete [REF]`
 
@@ -516,7 +516,7 @@ EXAMPLES
   Deleting item 80181ca6-d4aa-4575-9375-8f72b071111... Done
 ```
 
-_See code: [dist/commands/domains/delete.ts](https://github.com/fonoster/routr/blob/v2.4.1/mods/ctl/src/commands/domains/delete.ts)_
+_See code: [dist/commands/domains/delete.ts](https://github.com/fonoster/routr/blob/v2.4.2/mods/ctl/src/commands/domains/delete.ts)_
 
 ## `rctl domains describe [REF]`
 
@@ -538,7 +538,7 @@ DESCRIPTION
   show details of a Domain
 ```
 
-_See code: [dist/commands/domains/describe.ts](https://github.com/fonoster/routr/blob/v2.4.1/mods/ctl/src/commands/domains/describe.ts)_
+_See code: [dist/commands/domains/describe.ts](https://github.com/fonoster/routr/blob/v2.4.2/mods/ctl/src/commands/domains/describe.ts)_
 
 ## `rctl domains get [REF]`
 
@@ -567,7 +567,7 @@ EXAMPLES
   ab2b6959-f497-4b14-903b-85a7c464b564 Local Domain sip.local
 ```
 
-_See code: [dist/commands/domains/get.ts](https://github.com/fonoster/routr/blob/v2.4.1/mods/ctl/src/commands/domains/get.ts)_
+_See code: [dist/commands/domains/get.ts](https://github.com/fonoster/routr/blob/v2.4.2/mods/ctl/src/commands/domains/get.ts)_
 
 ## `rctl domains update REF`
 
@@ -593,7 +593,7 @@ EXAMPLES
   Updating Domain Local... 80181ca6-d4aa-4575-9375-8f72b07d5555
 ```
 
-_See code: [dist/commands/domains/update.ts](https://github.com/fonoster/routr/blob/v2.4.1/mods/ctl/src/commands/domains/update.ts)_
+_See code: [dist/commands/domains/update.ts](https://github.com/fonoster/routr/blob/v2.4.2/mods/ctl/src/commands/domains/update.ts)_
 
 ## `rctl numbers create`
 
@@ -616,7 +616,7 @@ EXAMPLES
   Creating Number (784) 317-8170... a134487f-a668-4509-9ddd-dcbc98175468
 ```
 
-_See code: [dist/commands/numbers/create.ts](https://github.com/fonoster/routr/blob/v2.4.1/mods/ctl/src/commands/numbers/create.ts)_
+_See code: [dist/commands/numbers/create.ts](https://github.com/fonoster/routr/blob/v2.4.2/mods/ctl/src/commands/numbers/create.ts)_
 
 ## `rctl numbers delete [REF]`
 
@@ -639,7 +639,7 @@ EXAMPLES
   Deleting item 80181ca6-d4aa-4575-9375-8f72b071111... Done
 ```
 
-_See code: [dist/commands/numbers/delete.ts](https://github.com/fonoster/routr/blob/v2.4.1/mods/ctl/src/commands/numbers/delete.ts)_
+_See code: [dist/commands/numbers/delete.ts](https://github.com/fonoster/routr/blob/v2.4.2/mods/ctl/src/commands/numbers/delete.ts)_
 
 ## `rctl numbers describe [REF]`
 
@@ -661,7 +661,7 @@ DESCRIPTION
   shows details for a Number
 ```
 
-_See code: [dist/commands/numbers/describe.ts](https://github.com/fonoster/routr/blob/v2.4.1/mods/ctl/src/commands/numbers/describe.ts)_
+_See code: [dist/commands/numbers/describe.ts](https://github.com/fonoster/routr/blob/v2.4.2/mods/ctl/src/commands/numbers/describe.ts)_
 
 ## `rctl numbers get [REF]`
 
@@ -690,7 +690,7 @@ EXAMPLES
   a134487f-a668-4509-9ddd-dcbc98175468 (785) 317-8070 +17853178070       sip:1001@sip.local Cameron, USA (US)
 ```
 
-_See code: [dist/commands/numbers/get.ts](https://github.com/fonoster/routr/blob/v2.4.1/mods/ctl/src/commands/numbers/get.ts)_
+_See code: [dist/commands/numbers/get.ts](https://github.com/fonoster/routr/blob/v2.4.2/mods/ctl/src/commands/numbers/get.ts)_
 
 ## `rctl numbers update REF`
 
@@ -716,7 +716,7 @@ EXAMPLES
   Updating Number (785) 317-8070... 80181ca6-d4aa-4575-9375-8f72b07d5555
 ```
 
-_See code: [dist/commands/numbers/update.ts](https://github.com/fonoster/routr/blob/v2.4.1/mods/ctl/src/commands/numbers/update.ts)_
+_See code: [dist/commands/numbers/update.ts](https://github.com/fonoster/routr/blob/v2.4.2/mods/ctl/src/commands/numbers/update.ts)_
 
 ## `rctl peers create`
 
@@ -739,7 +739,7 @@ EXAMPLES
   Creating Peer Asterisk Conference... b148b4b4-6884-4c06-bb7e-bd098f5fe793
 ```
 
-_See code: [dist/commands/peers/create.ts](https://github.com/fonoster/routr/blob/v2.4.1/mods/ctl/src/commands/peers/create.ts)_
+_See code: [dist/commands/peers/create.ts](https://github.com/fonoster/routr/blob/v2.4.2/mods/ctl/src/commands/peers/create.ts)_
 
 ## `rctl peers delete [REF]`
 
@@ -762,7 +762,7 @@ EXAMPLES
   Deleting item 80181ca6-d4aa-4575-9375-8f72b071111... Done
 ```
 
-_See code: [dist/commands/peers/delete.ts](https://github.com/fonoster/routr/blob/v2.4.1/mods/ctl/src/commands/peers/delete.ts)_
+_See code: [dist/commands/peers/delete.ts](https://github.com/fonoster/routr/blob/v2.4.2/mods/ctl/src/commands/peers/delete.ts)_
 
 ## `rctl peers describe [REF]`
 
@@ -784,7 +784,7 @@ DESCRIPTION
   shows details for a Peer
 ```
 
-_See code: [dist/commands/peers/describe.ts](https://github.com/fonoster/routr/blob/v2.4.1/mods/ctl/src/commands/peers/describe.ts)_
+_See code: [dist/commands/peers/describe.ts](https://github.com/fonoster/routr/blob/v2.4.2/mods/ctl/src/commands/peers/describe.ts)_
 
 ## `rctl peers get [REF]`
 
@@ -813,7 +813,7 @@ EXAMPLES
   6f941c63-880c-419a-a72a-4a107cbaf5c5 Asterisk Conference conference backend:conference ROUND_ROBIN         Yes
 ```
 
-_See code: [dist/commands/peers/get.ts](https://github.com/fonoster/routr/blob/v2.4.1/mods/ctl/src/commands/peers/get.ts)_
+_See code: [dist/commands/peers/get.ts](https://github.com/fonoster/routr/blob/v2.4.2/mods/ctl/src/commands/peers/get.ts)_
 
 ## `rctl peers update REF`
 
@@ -839,7 +839,7 @@ EXAMPLES
   Updating Peer Asterisk Conf... 80181ca6-d4aa-4575-9375-8f72b07d5555
 ```
 
-_See code: [dist/commands/peers/update.ts](https://github.com/fonoster/routr/blob/v2.4.1/mods/ctl/src/commands/peers/update.ts)_
+_See code: [dist/commands/peers/update.ts](https://github.com/fonoster/routr/blob/v2.4.2/mods/ctl/src/commands/peers/update.ts)_
 
 ## `rctl plugins`
 
@@ -1105,7 +1105,7 @@ EXAMPLES
   Creating Trunk T01... b148b4b4-6884-4c06-bb7e-bd098f5fe793
 ```
 
-_See code: [dist/commands/trunks/create.ts](https://github.com/fonoster/routr/blob/v2.4.1/mods/ctl/src/commands/trunks/create.ts)_
+_See code: [dist/commands/trunks/create.ts](https://github.com/fonoster/routr/blob/v2.4.2/mods/ctl/src/commands/trunks/create.ts)_
 
 ## `rctl trunks delete [REF]`
 
@@ -1128,7 +1128,7 @@ EXAMPLES
   Deleting item 80181ca6-d4aa-4575-9375-8f72b071111... Done
 ```
 
-_See code: [dist/commands/trunks/delete.ts](https://github.com/fonoster/routr/blob/v2.4.1/mods/ctl/src/commands/trunks/delete.ts)_
+_See code: [dist/commands/trunks/delete.ts](https://github.com/fonoster/routr/blob/v2.4.2/mods/ctl/src/commands/trunks/delete.ts)_
 
 ## `rctl trunks describe [REF]`
 
@@ -1150,7 +1150,7 @@ DESCRIPTION
   shows details for a Trunk
 ```
 
-_See code: [dist/commands/trunks/describe.ts](https://github.com/fonoster/routr/blob/v2.4.1/mods/ctl/src/commands/trunks/describe.ts)_
+_See code: [dist/commands/trunks/describe.ts](https://github.com/fonoster/routr/blob/v2.4.2/mods/ctl/src/commands/trunks/describe.ts)_
 
 ## `rctl trunks get [REF]`
 
@@ -1179,7 +1179,7 @@ EXAMPLES
   8cde8ea9-3c58-4dbe-b2cf-23c4413dd4cc Local  sip.t01.provider.net
 ```
 
-_See code: [dist/commands/trunks/get.ts](https://github.com/fonoster/routr/blob/v2.4.1/mods/ctl/src/commands/trunks/get.ts)_
+_See code: [dist/commands/trunks/get.ts](https://github.com/fonoster/routr/blob/v2.4.2/mods/ctl/src/commands/trunks/get.ts)_
 
 ## `rctl trunks update REF`
 
@@ -1205,5 +1205,5 @@ EXAMPLES
   Updating Trunk T01... 80181ca6-d4aa-4575-9375-8f72b07d5555
 ```
 
-_See code: [dist/commands/trunks/update.ts](https://github.com/fonoster/routr/blob/v2.4.1/mods/ctl/src/commands/trunks/update.ts)_
+_See code: [dist/commands/trunks/update.ts](https://github.com/fonoster/routr/blob/v2.4.2/mods/ctl/src/commands/trunks/update.ts)_
 <!-- commandsstop -->

--- a/mods/ctl/package-lock.json
+++ b/mods/ctl/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@routr/ctl",
-  "version": "2.4.1",
+  "version": "2.4.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@routr/ctl",
-      "version": "2.4.1",
+      "version": "2.4.2",
       "license": "MIT",
       "dependencies": {
         "@oclif/core": "^1.24.0",
@@ -15,7 +15,7 @@
         "@oclif/plugin-plugins": "^2.1.12",
         "@oclif/plugin-warn-if-update-available": "^2.0.19",
         "@routr/common": "^2.4.1",
-        "@routr/sdk": "^2.4.1",
+        "@routr/sdk": "^2.4.2",
         "figlet": "^1.5.2",
         "fuzzy-search": "^3.2.1",
         "inquirer": "^8.2.5",

--- a/mods/ctl/package.json
+++ b/mods/ctl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@routr/ctl",
-  "version": "2.4.1",
+  "version": "2.4.2",
   "description": "Routr Command-Line Tool",
   "author": "Pedro Sanders <psanders@fonoster.com>",
   "bin": {
@@ -26,7 +26,7 @@
     "@oclif/plugin-plugins": "^2.1.12",
     "@oclif/plugin-warn-if-update-available": "^2.0.19",
     "@routr/common": "^2.4.1",
-    "@routr/sdk": "^2.4.1",
+    "@routr/sdk": "^2.4.2",
     "figlet": "^1.5.2",
     "fuzzy-search": "^3.2.1",
     "inquirer": "^8.2.5",

--- a/mods/dispatcher/package.json
+++ b/mods/dispatcher/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@routr/dispatcher",
-  "version": "2.4.1",
+  "version": "2.4.2",
   "description": "Receives SIP messages and forwards them to the corresponding Message Processor",
   "author": "Pedro Sanders <psanders@fonoster.com>",
   "homepage": "https://github.com/fonoster/routr#readme",

--- a/mods/dispatcher/src/connections.ts
+++ b/mods/dispatcher/src/connections.ts
@@ -18,7 +18,7 @@
  */
 import { ProcessorGPRCConnection } from "./types"
 import { ProcessorConfig, PROCESSOR_OBJECT_PROTO } from "@routr/common"
-import { MiddlewareConfig } from "@routr/common/src/types"
+import { CommonTypes } from "@routr/common"
 import * as grpc from "@grpc/grpc-js"
 
 /**
@@ -29,7 +29,7 @@ import * as grpc from "@grpc/grpc-js"
  * @return {ProcessorGPRCConnection}
  */
 export default function connectToBackend(
-  processors: ProcessorConfig[] | MiddlewareConfig[]
+  processors: ProcessorConfig[] | CommonTypes.MiddlewareConfig[]
 ): Map<string, ProcessorGPRCConnection> {
   const procs = processors ? [...processors] : []
   const connections = new Map<string, ProcessorGPRCConnection>()

--- a/mods/location/package.json
+++ b/mods/location/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@routr/location",
-  "version": "2.4.1",
+  "version": "2.4.2",
   "description": "Creates and maintains a list of routes to all registered endpoints",
   "author": "Pedro Sanders <psanders@fonoster.com>",
   "homepage": "https://github.com/fonoster/routr#readme",

--- a/mods/location/src/index.ts
+++ b/mods/location/src/index.ts
@@ -24,6 +24,7 @@ import LocationClient from "./client"
 export * as Helper from "./helper"
 export * as Utils from "./utils"
 export * from "./errors"
+export * from "./types"
 
 export { LocationClient, ILocationService, getConfig }
 export { LocationConfig, CacheProvider, locationService }

--- a/mods/one/package.json
+++ b/mods/one/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@routr/one",
-  "version": "2.4.1",
+  "version": "2.4.2",
   "description": "Bundle server with everything needed to run Routr Connect",
   "author": "Pedro Sanders <psanders@fonoster.com>",
   "homepage": "https://github.com/fonoster/routr#readme",
@@ -21,9 +21,9 @@
   "dependencies": {
     "@fonoster/logger": "0.3.20",
     "@routr/common": "^2.4.1",
-    "@routr/connect": "^2.4.1",
-    "@routr/dispatcher": "^2.4.1",
-    "@routr/location": "^2.4.1",
+    "@routr/connect": "^2.4.2",
+    "@routr/dispatcher": "^2.4.2",
+    "@routr/location": "^2.4.2",
     "@routr/pgdata": "^2.4.1",
     "@routr/rtprelay": "^2.4.1"
   },

--- a/mods/registry/package-lock.json
+++ b/mods/registry/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@routr/registry",
-  "version": "2.4.1",
+  "version": "2.4.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@routr/registry",
-      "version": "2.4.1",
+      "version": "2.4.2",
       "license": "MIT",
       "dependencies": {
         "@grpc/grpc-js": "^1.8.4",

--- a/mods/registry/package.json
+++ b/mods/registry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@routr/registry",
-  "version": "2.4.1",
+  "version": "2.4.2",
   "description": "Sends trunks registrations and maintains their bindings",
   "author": "Pedro Sanders <psanders@fonoster.com>",
   "homepage": "https://github.com/fonoster/routr#readme",

--- a/mods/registry/src/service.ts
+++ b/mods/registry/src/service.ts
@@ -35,7 +35,6 @@ import {
   CommonTypes as CT
 } from "@routr/common"
 import { getLogger } from "@fonoster/logger"
-import { SIPMessage } from "@routr/common/src/types"
 
 const logger = getLogger({ service: "registry", filePath: __filename })
 
@@ -98,7 +97,7 @@ export default function registryService(config: RegistryConfig) {
         return
       }
 
-      const message = result.value.message as SIPMessage
+      const message = result.value.message as CT.SIPMessage
 
       // Makes sure we send register before the last register expires
       const retentionTime =

--- a/mods/sdk/README.md
+++ b/mods/sdk/README.md
@@ -21,12 +21,12 @@ $ npm install --save @routr/sdk
 # APIs
 <!-- apis -->
 * [`Access Control List`](#acl--apiclient)
-* [`Agents`](#Agents)
-* [`Credentials`](#Credentials)
-* [`Domains`](#Domains)
-* [`Numbers`](#Numbers)
-* [`Peers`](#Peers)
-* [`Trunks`](#Trunks)
+* [`Agents`](#agents--apiclient)
+* [`Credentials`](#credentials--apiclient)
+* [`Domains`](#domains--apiclient)
+* [`Numbers`](#numbers--apiclient)
+* [`Peers`](#peers--apiclient)
+* [`Trunks`](#trunks--apiclient)
 
 
 <a name="ACL"></a>

--- a/mods/sdk/package-lock.json
+++ b/mods/sdk/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@routr/sdk",
-  "version": "2.4.1",
+  "version": "2.4.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@routr/sdk",
-      "version": "2.4.1",
+      "version": "2.4.2",
       "license": "MIT",
       "dependencies": {
         "@fonoster/logger": "0.3.20",

--- a/mods/sdk/package.json
+++ b/mods/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@routr/sdk",
-  "version": "2.4.1",
+  "version": "2.4.2",
   "description": "The Routr SDK for Node.js",
   "author": "Pedro Sanders <psanders@fonoster.com>",
   "homepage": "https://github.com/fonoster/routr#readme",

--- a/mods/sdk/src/client.ts
+++ b/mods/sdk/src/client.ts
@@ -20,12 +20,11 @@
 import * as grpc from "@grpc/grpc-js"
 import { Metadata } from "@grpc/grpc-js"
 import { CommonConnect as CC, Assertions as A } from "@routr/common"
-import { APIClient as ConnectClient } from "@routr/common/src/connect"
 import { ClientOptions } from "./types"
 import fs from "fs"
 
 export abstract class APIClient {
-  client: ConnectClient
+  client: CC.APIClient
   constructor(options: ClientOptions) {
     const metadata = new Metadata()
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -105,7 +105,7 @@
     },
     "mods/connect": {
       "name": "@routr/connect",
-      "version": "2.4.1",
+      "version": "2.4.2",
       "license": "MIT",
       "dependencies": {
         "@fonoster/logger": "0.3.20",
@@ -118,7 +118,7 @@
         "@opentelemetry/sdk-trace-node": "^1.0.4",
         "@opentelemetry/semantic-conventions": "^1.0.4",
         "@routr/common": "^2.4.1",
-        "@routr/location": "^2.4.1",
+        "@routr/location": "^2.4.2",
         "@routr/processor": "^2.4.1",
         "jsonwebtoken": "^9.0.0"
       },
@@ -131,7 +131,7 @@
     },
     "mods/ctl": {
       "name": "@routr/ctl",
-      "version": "2.4.1",
+      "version": "2.4.2",
       "license": "MIT",
       "dependencies": {
         "@oclif/core": "^1.24.0",
@@ -140,7 +140,7 @@
         "@oclif/plugin-plugins": "^2.1.12",
         "@oclif/plugin-warn-if-update-available": "^2.0.19",
         "@routr/common": "^2.4.1",
-        "@routr/sdk": "^2.4.1",
+        "@routr/sdk": "^2.4.2",
         "figlet": "^1.5.2",
         "fuzzy-search": "^3.2.1",
         "inquirer": "^8.2.5",
@@ -175,7 +175,7 @@
     },
     "mods/dispatcher": {
       "name": "@routr/dispatcher",
-      "version": "2.4.1",
+      "version": "2.4.2",
       "license": "MIT",
       "dependencies": {
         "@fonoster/logger": "0.3.20",
@@ -232,7 +232,7 @@
     },
     "mods/location": {
       "name": "@routr/location",
-      "version": "2.4.1",
+      "version": "2.4.2",
       "license": "MIT",
       "dependencies": {
         "@fonoster/logger": "0.3.20",
@@ -257,14 +257,14 @@
     },
     "mods/one": {
       "name": "@routr/one",
-      "version": "2.4.1",
+      "version": "2.4.2",
       "license": "MIT",
       "dependencies": {
         "@fonoster/logger": "0.3.20",
         "@routr/common": "^2.4.1",
-        "@routr/connect": "^2.4.1",
-        "@routr/dispatcher": "^2.4.1",
-        "@routr/location": "^2.4.1",
+        "@routr/connect": "^2.4.2",
+        "@routr/dispatcher": "^2.4.2",
+        "@routr/location": "^2.4.2",
         "@routr/pgdata": "^2.4.1",
         "@routr/rtprelay": "^2.4.1"
       },
@@ -329,7 +329,7 @@
     },
     "mods/registry": {
       "name": "@routr/registry",
-      "version": "2.4.1",
+      "version": "2.4.2",
       "license": "MIT",
       "dependencies": {
         "@grpc/grpc-js": "^1.8.4",
@@ -391,7 +391,7 @@
     },
     "mods/sdk": {
       "name": "@routr/sdk",
-      "version": "2.4.1",
+      "version": "2.4.2",
       "license": "MIT",
       "dependencies": {
         "@fonoster/logger": "0.3.20",
@@ -22154,7 +22154,7 @@
         "@opentelemetry/sdk-trace-node": "^1.0.4",
         "@opentelemetry/semantic-conventions": "^1.0.4",
         "@routr/common": "^2.4.1",
-        "@routr/location": "^2.4.1",
+        "@routr/location": "^2.4.2",
         "@routr/processor": "^2.4.1",
         "@types/jsonwebtoken": "^9.0.1",
         "jsonwebtoken": "^9.0.0"
@@ -22170,7 +22170,7 @@
         "@oclif/plugin-warn-if-update-available": "^2.0.19",
         "@oclif/test": "^2.2.20",
         "@routr/common": "^2.4.1",
-        "@routr/sdk": "^2.4.1",
+        "@routr/sdk": "^2.4.2",
         "@types/chai": "^4.2.11",
         "@types/figlet": "^1.5.5",
         "@types/fuzzy-search": "^2.1.2",
@@ -22264,9 +22264,9 @@
       "requires": {
         "@fonoster/logger": "0.3.20",
         "@routr/common": "^2.4.1",
-        "@routr/connect": "^2.4.1",
-        "@routr/dispatcher": "^2.4.1",
-        "@routr/location": "^2.4.1",
+        "@routr/connect": "^2.4.2",
+        "@routr/dispatcher": "^2.4.2",
+        "@routr/location": "^2.4.2",
         "@routr/pgdata": "^2.4.1",
         "@routr/rtprelay": "^2.4.1"
       }


### PR DESCRIPTION
## Description

TL;DR →  Closes #233

This PR resolves a build issue that was observed when working with routr/sdk. The error was pinpointed to an incorrect type import path in routr/mods/sdk/src/client.ts. The faulty path was referencing a src directory, which was not present:

```
node_modules/@routr/sdk/dist/client.d.ts:2:44 - error TS2307: Cannot find module '@routr/common/src/connect' or its corresponding type declarations.
```

After carefully examining the npm package structure of the `@routr/common` repository, it became evident that the correct path should omit the "src" segment. This PR makes that adjustment to ensure successful builds with `@routr/sdk`

> PR comment reviewed with AI

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

I ran the `npm run build` command and all unit test pass and builds ends without errors.

## Checklist:

<!-- Please delete options that are not relevant. -->

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
