### PR TITLE
Fix SIP.js SDP error - update utils.ts with correct SDES parameter

### DIFF
--- a/mods/rtprelay/src/utils.ts
+++ b/mods/rtprelay/src/utils.ts
@@ -59,7 +59,7 @@ export function getRTPEParamsByDirection(dir: Direction) {
     case Direction.WEB_TO_WEB:
       return {
         ICE: "force",
-        SDES: "off",
+        SDES: ["off"],
         flags: ["trust-address", "replace-origin", "replace-session-connection"]
       }
     case Direction.WEB_TO_PHONE:
@@ -74,7 +74,7 @@ export function getRTPEParamsByDirection(dir: Direction) {
         "transport-protocol": "UDP/TLS/RTP/SAVPF",
         "rtcp-mux": "require",
         ICE: "force",
-        SDES: "off",
+        SDES: ["off"],
         flags: [
           "trust-address",
           "replace-origin",


### PR DESCRIPTION
## Description

Fixed incorrectly encoded SDES parameter in the NG protocol config. SDES parameters are supplied in an array, not a single string. See here: https://github.com/sipwise/rtpengine/issues/433

This cures `Failed to set remote offer sdp: SDES and DTLS-SRTP cannot be enabled at the same time.` error in SIP.js

See https://github.com/fonoster/routr/issues/280

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

I have not been able to test this directly as I don't know how to build the routr-one docker image. However I have built a new docker image based on routr-one:latest with a modified utils.js and this fixes the issue. I was advised by Pedro Sanders that I should submit a pull request and allow the team to perform tests.

## Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
