### PR TITLE
Bump heplify version to avoid panic at startup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN apk add --no-cache --update cmake curl g++ git make nodejs npm openjdk17-jdk
   && cd node_modules/@routr/pgdata/ && npx prisma generate \
   && cd /work && curl -sf https://gobinaries.com/tj/node-prune | sh && node-prune 
 
-ADD https://github.com/sipcapture/heplify/releases/download/v1.65.10/heplify /work/heplify
+ADD https://github.com/sipcapture/heplify/releases/download/v1.67.0/heplify /work/heplify
 RUN chmod +x heplify
 
 ##  


### PR DESCRIPTION
## Description

The heplify version bundled with routr has a bug that causes a panic at start up.

The problem was fixed on release v1.66.4

> https://github.com/sipcapture/heplify/releases/tag/v1.66.4
> fixed panic for multiple hosts

To avoid these and other issues, let's update the tool to the latest release.

## Type of change

<!-- 
  Choose all that apply and delete options that are not relevant.
-->

- [x] Bug fix (non-breaking change which fixes an issue)

<!--
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
-->

## How Has This Been Tested?

We created a derivate image based on the original overriding the existing binary with the up-to-date version.
```
FROM fonoster/routr-one:latest
ARG HEPLIFY_VERSION=v1.67.0
ADD https://github.com/sipcapture/heplify/releases/download/${HEPLIFY_VERSION}/heplify /usr/local/bin/heplify
RUN chmod +x /usr/local/bin/heplify
```

## Checklist:

<!-- Please delete options that are not relevant. -->
- [x] I have performed a self-review of my code
<!--
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
-->