### PR TITLE
fix(rtprelay): service selecting unrelated pods due to missing label

### DIFF
--- a/ops/charts/connect/templates/rtprelay/service.yaml
+++ b/ops/charts/connect/templates/rtprelay/service.yaml
@@ -16,6 +16,7 @@ spec:
   - port: 51903
     targetPort: 51903
   selector:
-    {{- include ".helm.selectorLabels" . | nindent 6 }}
+    {{- include ".helm.selectorLabels" . | nindent 4 }}
+    service: rtprelay
 
 {{- end }}


### PR DESCRIPTION
## Description

In 7a056ffd9 (feat: code cleanup and minor fixes, 2023-02-13), deployments were updated to include a `service` label, and services were modified to target that label. The rtprelay service was not updated at the time, causing it to select unrelated pods.

## Type of change

<!-- 
  Choose all that apply and delete options that are not relevant.
-->

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

<!-- 
  Please describe the tests that you ran to verify your changes. 
  Provide instructions so we can reproduce. 
  Please also list any relevant details for your test configuration 
-->

## Checklist:

<!-- Please delete options that are not relevant. -->

- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings