### PR TITLE
fix(location): dispatch RemoveRoutes to locator.removeRoutes

### DIFF
--- a/mods/location/src/utils.ts
+++ b/mods/location/src/utils.ts
@@ -23,7 +23,12 @@ import {
   CommonTypes as CT
 } from "@routr/common"
 import { NotRoutesFoundForAOR } from "./errors"
-import { AddRouteRequest, FindRoutesRequest, ILocationService } from "./types"
+import {
+  AddRouteRequest,
+  FindRoutesRequest,
+  ILocationService,
+  RemoveRoutesRequest
+} from "./types"
 
 export const expiredFilter = (r: Route) =>
   r.expires - (Date.now() - r.registeredOn) / 1000 > 0
@@ -78,9 +83,8 @@ export const getServiceInfo = (
       },
       removeRoutes: async (call: CT.GrpcCall, callback) => {
         try {
-          callback(null, {
-            routes: await locator.findRoutes(call.request as FindRoutesRequest)
-          })
+          await locator.removeRoutes(call.request as RemoveRoutesRequest)
+          callback(null, {})
         } catch (e) {
           callback(e, null)
         }

--- a/mods/location/test/utils.unit.test.ts
+++ b/mods/location/test/utils.unit.test.ts
@@ -19,8 +19,14 @@
 import chai from "chai"
 import sinon from "sinon"
 import sinonChai from "sinon-chai"
-import { configFromString, duplicateFilter, expiredFilter } from "../src/utils"
+import {
+  configFromString,
+  duplicateFilter,
+  expiredFilter,
+  getServiceInfo
+} from "../src/utils"
 import * as Routes from "./route_examples"
+import { ILocationService } from "../src/types"
 
 const expect = chai.expect
 chai.use(sinonChai)
@@ -28,6 +34,45 @@ const sandbox = sinon.createSandbox()
 
 describe("@routr/location", () => {
   afterEach(() => sandbox.restore())
+
+  it("dispatches removeRoutes to locator.removeRoutes and returns Empty", async () => {
+    const locator = {
+      removeRoutes: sandbox.stub().resolves(),
+      findRoutes: sandbox.stub().resolves([{ host: "still-registered" }]),
+      addRoute: sandbox.stub().resolves()
+    } as unknown as ILocationService
+
+    const handlers = getServiceInfo("0.0.0.0:51902", locator).handlers
+    const request = { aor: "sip:alice@example.test" }
+    const callback = sandbox.spy()
+
+    await handlers.removeRoutes({ request }, callback)
+
+    expect(locator.removeRoutes).to.have.been.calledOnceWithExactly(request)
+    expect(locator.findRoutes).to.not.have.been.called
+    expect(callback).to.have.been.calledOnceWithExactly(null, {})
+  })
+
+  it("dispatches addRoute to locator.addRoute and returns Empty", async () => {
+    const locator = {
+      removeRoutes: sandbox.stub().resolves(),
+      findRoutes: sandbox.stub().resolves([]),
+      addRoute: sandbox.stub().resolves()
+    } as unknown as ILocationService
+
+    const handlers = getServiceInfo("0.0.0.0:51902", locator).handlers
+    const request = {
+      aor: "sip:alice@example.test",
+      route: { host: "sip.local" }
+    }
+    const callback = sandbox.spy()
+
+    await handlers.addRoute({ request }, callback)
+
+    expect(locator.addRoute).to.have.been.calledOnceWithExactly(request)
+    expect(locator.findRoutes).to.not.have.been.called
+    expect(callback).to.have.been.calledOnceWithExactly(null, {})
+  })
 
   it("verifies that a route is not expired", () => {
     const route1 = { ...Routes.simpleRoute01 }


### PR DESCRIPTION
## Summary
- Fix the Location `RemoveRoutes` gRPC handler so it calls `locator.removeRoutes` and returns `Empty`, matching the protobuf contract and neighboring `addRoute` handler.
- Previously the handler invoked `findRoutes` and returned route data, so deregistered AORs could remain routable.
- Add regression coverage for `removeRoutes` (and a neighboring `addRoute` control) in `mods/location/test/utils.unit.test.ts`.

Fixes #352

## Test plan
- [x] `npm test` (unit suite, including new location handler tests)
- [x] Pre-commit hooks: format, lint, typecheck
- [ ] Maintainer review of `mods/location/src/utils.ts` handler dispatch


Made with [Cursor](https://cursor.com)