### PR TITLE
fix(processor): rewrite requestUri.user in fixRequestURI

### DIFF
--- a/mods/processor/src/alterations.ts
+++ b/mods/processor/src/alterations.ts
@@ -34,6 +34,9 @@ export const fixRequestURI =
   (route: Route) =>
   (request: MessageRequest): MessageRequest => {
     const req = H.deepCopy(request)
+    if (route.user) {
+      req.message.requestUri.user = route.user
+    }
     req.message.requestUri.host = route.host
     req.message.requestUri.port = route.port
     req.message.requestUri.transportParam = route.transport

--- a/mods/processor/src/alterations.ts
+++ b/mods/processor/src/alterations.ts
@@ -34,7 +34,7 @@ export const fixRequestURI =
   (route: Route) =>
   (request: MessageRequest): MessageRequest => {
     const req = H.deepCopy(request)
-    if (route.user) {
+    if (route.registeredOn && route.user) {
       req.message.requestUri.user = route.user
     }
     req.message.requestUri.host = route.host

--- a/mods/processor/test/alterations.unit.test.ts
+++ b/mods/processor/test/alterations.unit.test.ts
@@ -56,6 +56,46 @@ describe("@routr/processor/alterations", () => {
       .to.be.equal(route.transport)
   })
 
+  // The original dialed identifier (e.g. a PSTN DID) as it arrives in the
+  // Request-URI before fixRequestURI runs.
+  const dialedNumber = "17853178070"
+  const requestWithDialedNumber = {
+    ...request,
+    message: {
+      ...request.message,
+      requestUri: { ...request.message.requestUri, user: dialedNumber }
+    }
+  }
+
+  it("rewrites the request uri user with the route user for a registered route", () => {
+    const r = A.fixRequestURI(route)(requestWithDialedNumber)
+    expect(r)
+      .to.have.property("message")
+      .to.have.property("requestUri")
+      .to.have.property("user")
+      .to.be.equal(route.user)
+  })
+
+  it("keeps the original request uri user when route.user is falsy (outbound trunk)", () => {
+    const r = A.fixRequestURI({ ...route, user: "" })(requestWithDialedNumber)
+    expect(r)
+      .to.have.property("message")
+      .to.have.property("requestUri")
+      .to.have.property("user")
+      .to.be.equal(dialedNumber)
+  })
+
+  it("keeps the original request uri user when the route is not registered", () => {
+    const r = A.fixRequestURI({ ...route, registeredOn: undefined })(
+      requestWithDialedNumber
+    )
+    expect(r)
+      .to.have.property("message")
+      .to.have.property("requestUri")
+      .to.have.property("user")
+      .to.be.equal(dialedNumber)
+  })
+
   it("updates the value of the max forwards header", () => {
     const r = A.decreaseMaxForwards(request)
     expect(r)


### PR DESCRIPTION
## Description

`fixRequestURI` (`mods/processor/src/alterations.ts`, applied via `tailor.ts`
for every relayed request) rewrites the outgoing Request-URI's
`host`/`port`/`transportParam` from the matched `route`, but never its
`user` part. For a call routed to an Agent via location lookup (e.g.
`FROM_PSTN`), this leaves the *original dialed identifier* in the
Request-URI's user part instead of the target's own SIP username — even
though `route.user` is populated correctly (captured at REGISTER time from
the target's own From-header username).

In practice: an inbound PSTN call dialing a DID gets correctly routed by
routr all the way to the destination Agent's registered contact (trunk
match, Number match, and location lookup all succeed — confirmed with a
two-leg packet capture showing the INVITE genuinely leaving routr for the
right IP:port), but the outgoing INVITE reads
`sip:<the original DID>@<agent's contact>` instead of
`sip:<agent's own username>@<agent's contact>`. Strict SIP UAs (e.g. a
Linksys/Sipura ATA) check the Request-URI user against their own registered
identity and reject the mismatch with `404 Not Found`, even though routr did
everything else right.

The existing comment on this function ("Forces the requestURI to be the same
as the trunk uri. This is a workaround for Twilio.") suggests it was built
for outbound trunk routing, where preserving the caller-dialed number in the
R-URI is usually correct, and was never extended to handle inbound-to-Agent
routing, where the R-URI needs to reflect the *destination's* identity.

The fix is conditional on `route.user` being truthy: outbound trunk routes
built via `getTrunkURI()` may have no configured `trunk.uris[0].user`, so
this deliberately preserves today's fallback behaviour (leaving the original
Request-URI user untouched) for that path rather than risking rewriting a
working outbound R-URI to `undefined@host`.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Reproduced and fixed against a real self-hosted deployment: an inbound PSTN
call to a DID, routed to an Agent whose username differs from the dialed
DID (the normal case for any PSTN-to-extension call). Before the fix: routr
correctly resolves the route but the destination UA rejects the call with
404. After the fix, verified via a two-leg packet capture: the INVITE
correctly carries the Agent's own username, the destination UA responds
`180 Ringing` then `200 OK`, the call completes with two-way audio, and
hangs up cleanly (`BYE`/`200 OK`) afterward.

I checked this deployment currently has zero configured `trunk_uris` rows
(no outbound trunk provisioned yet), so the `route.user`-empty fallback path
used by outbound trunk routing is not exercised live by this test — the
conditional is a deliberate design choice to avoid touching that path, not
something I've verified end-to-end.

I have not run the project's own test suite (`npm test`) against this
change.

## Checklist:

- [x] I have performed a self-review of my code
- [ ] (rest left unchecked — not verified)
