### PR TITLE
fix(simpledata): keep zero maxContacts instead of rewriting as unlimited

### DIFF
--- a/mods/connect/src/handlers/register.ts
+++ b/mods/connect/src/handlers/register.ts
@@ -117,7 +117,7 @@ export const handleRegister = (
         await location.addRoute({
           aor: payload.aor,
           route: H.createRoute(request),
-          maxContacts: payload.maxContacts || -1
+          maxContacts: payload.maxContacts ?? -1
         })
 
         res.sendRegisterOk(request)

--- a/mods/location/test/location.unit.test.ts
+++ b/mods/location/test/location.unit.test.ts
@@ -279,6 +279,21 @@ describe("@routr/location", () => {
       .to.be.equal("conference01")
   })
 
+  it("rejects the first new route when maxContacts is zero", async () => {
+    const locator = new Locator(new MemoryStore())
+
+    try {
+      await locator.addRoute({
+        aor: "sip:voice@sip.local",
+        route: Routes.voiceBackendRoute01,
+        maxContacts: 0
+      })
+      throw new Error("Test failed - no error thrown")
+    } catch (error) {
+      expect(error.message).to.equal("exceeds maximum of 0 allowed contacts")
+    }
+  })
+
   it("checks if maxContacts has been reached (passing a different route)", async () => {
     const locator = new Locator(new MemoryStore())
     await locator.addRoute({

--- a/mods/simpledata/src/loaders/agents.ts
+++ b/mods/simpledata/src/loaders/agents.ts
@@ -34,8 +34,8 @@ export function agentsLoader(
     list
   ) as CC.Credentials
 
-  // maxContacts -1 means no limit
-  agent.maxContacts = agent.maxContacts || -1
+  // maxContacts -1 means no limit; 0 is a hard limit (no contacts)
+  agent.maxContacts = agent.maxContacts ?? -1
 
   return agent
 }

--- a/mods/simpledata/src/loaders/peers.ts
+++ b/mods/simpledata/src/loaders/peers.ts
@@ -43,8 +43,8 @@ export function peersLoader(
     list
   ) as CC.Credentials
 
-  // maxContacts -1 means no limit
-  peer.maxContacts = peer.maxContacts || -1
+  // maxContacts -1 means no limit; 0 is a hard limit (no contacts)
+  peer.maxContacts = peer.maxContacts ?? -1
 
   return peer
 }

--- a/mods/simpledata/test/loaders.unit.test.ts
+++ b/mods/simpledata/test/loaders.unit.test.ts
@@ -1,0 +1,104 @@
+/*
+ * Copyright (C) 2026 by Fonoster Inc (https://fonoster.com)
+ * http://github.com/fonoster/routr
+ *
+ * This file is part of Routr.
+ *
+ * Licensed under the MIT License (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    https://opensource.org/licenses/MIT
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import chai from "chai"
+import sinon from "sinon"
+import sinonChai from "sinon-chai"
+import { CommonConnect as CC } from "@routr/common"
+import { agentsLoader } from "../src/loaders/agents"
+import { peersLoader } from "../src/loaders/peers"
+
+const expect = chai.expect
+chai.use(sinonChai)
+const sandbox = sinon.createSandbox()
+
+describe("@routr/simpledata/loaders", () => {
+  afterEach(() => sandbox.restore())
+
+  it("preserves a zero Agent maxContacts instead of rewriting it as unlimited", () => {
+    const agent = agentsLoader(
+      {
+        apiVersion: CC.APIVersion.V2BETA1,
+        kind: CC.Kind.AGENT,
+        ref: "agent-01",
+        metadata: { name: "Zero Contact Agent" },
+        spec: {
+          username: "1001",
+          maxContacts: 0
+        }
+      } as CC.UserConfig,
+      []
+    )
+
+    expect(agent.maxContacts).to.equal(0)
+  })
+
+  it("defaults a missing Agent maxContacts to unlimited", () => {
+    const agent = agentsLoader(
+      {
+        apiVersion: CC.APIVersion.V2BETA1,
+        kind: CC.Kind.AGENT,
+        ref: "agent-01",
+        metadata: { name: "Unlimited Agent" },
+        spec: {
+          username: "1001"
+        }
+      } as CC.UserConfig,
+      []
+    )
+
+    expect(agent.maxContacts).to.equal(-1)
+  })
+
+  it("preserves a zero Peer maxContacts instead of rewriting it as unlimited", () => {
+    const peer = peersLoader(
+      {
+        apiVersion: CC.APIVersion.V2BETA1,
+        kind: CC.Kind.PEER,
+        ref: "peer-01",
+        metadata: { name: "Zero Contact Peer" },
+        spec: {
+          username: "peer",
+          aor: "sip:peer@sip.local",
+          maxContacts: 0
+        }
+      } as CC.UserConfig,
+      []
+    )
+
+    expect(peer.maxContacts).to.equal(0)
+  })
+
+  it("defaults a missing Peer maxContacts to unlimited", () => {
+    const peer = peersLoader(
+      {
+        apiVersion: CC.APIVersion.V2BETA1,
+        kind: CC.Kind.PEER,
+        ref: "peer-01",
+        metadata: { name: "Unlimited Peer" },
+        spec: {
+          username: "peer",
+          aor: "sip:peer@sip.local"
+        }
+      } as CC.UserConfig,
+      []
+    )
+
+    expect(peer.maxContacts).to.equal(-1)
+  })
+})


### PR DESCRIPTION
## Summary
- SimpleData Agent/Peer loaders and connect-token registration used `value || -1`, which treats an explicit `0` as falsy and rewrites it to the unlimited sentinel (`-1`).
- Location already treats `0` as a hard no-contacts limit (`maxContacts !== -1` and `existingRoutes.length >= maxContacts`), so the loaders were undoing a valid configuration.
- Default with nullish coalescing (`?? -1`) so missing values stay unlimited and `0` is preserved.

Fixes #351

## Test plan
- [x] Loader unit tests: Agent/Peer `maxContacts: 0` is preserved; omitted `maxContacts` still defaults to `-1`
- [x] Location unit test: first new route is rejected when `maxContacts` is `0`
- [x] `npm test` (unit suite)
- [x] Pre-commit hooks: format, lint, typecheck


Made with [Cursor](https://cursor.com)