### PR TITLE
fix(processor): strip X-Edgeport-Ref with case-insensitive compare

### DIFF
--- a/mods/processor/src/alterations.ts
+++ b/mods/processor/src/alterations.ts
@@ -281,7 +281,8 @@ export const removeXEdgePortRef = (request: MessageRequest): MessageRequest => {
   const req = H.deepCopy(request)
   req.message.extensions = req.message.extensions.filter(
     (ext: CommonTypes.Extension) =>
-      ext.name.toLowerCase() !== CommonTypes.ExtraHeader.EDGEPORT_REF
+      ext.name.toLowerCase() !==
+      CommonTypes.ExtraHeader.EDGEPORT_REF.toLowerCase()
   )
   return req
 }

--- a/mods/processor/test/alterations.unit.test.ts
+++ b/mods/processor/test/alterations.unit.test.ts
@@ -150,6 +150,33 @@ describe("@routr/processor/alterations", () => {
     expect(E.getHeaderValue(r, "user-agent")).to.be.null
   })
 
+  it("removes the canonical X-Edgeport-Ref extension", () => {
+    const withHeader = A.addXEdgePortRef(request)
+    expect(E.getHeaderValue(withHeader, CT.ExtraHeader.EDGEPORT_REF)).to.equal(
+      request.edgePortRef
+    )
+
+    const cleaned = A.removeXEdgePortRef(withHeader)
+    expect(E.getHeaderValue(cleaned, CT.ExtraHeader.EDGEPORT_REF)).to.be.null
+    expect(cleaned.message.extensions.find((ext) => ext.name === "CSeq")).to
+      .exist
+  })
+
+  it("strips X-Edgeport-Ref regardless of header-name case", () => {
+    const req = {
+      ...request,
+      message: {
+        ...request.message,
+        extensions: [
+          ...request.message.extensions,
+          { name: "x-edgeport-ref", value: "edgeport-01" }
+        ]
+      }
+    }
+    const cleaned = A.removeXEdgePortRef(req)
+    expect(E.getHeaderValue(cleaned, CT.ExtraHeader.EDGEPORT_REF)).to.be.null
+  })
+
   it("pipes alterations and checks the result", () => {
     const result = pipe(
       request,


### PR DESCRIPTION
## Summary
- `removeXEdgePortRef` lowercased each extension name, then compared it to the mixed-case `ExtraHeader.EDGEPORT_REF` (`X-Edgeport-Ref`).
- That equality never holds for the canonical header, so Connect tailoring and registry return processing forwarded `X-Edgeport-Ref` outbound.
- Normalize both sides, matching neighboring `getHeaderValue`.

Fixes #355

## Test plan
- [x] Alteration unit tests: canonical `X-Edgeport-Ref` is removed; lowercase `x-edgeport-ref` is also removed; other extensions remain
- [x] `npm test` (unit suite)
- [x] Pre-commit hooks: format, lint, typecheck


Made with [Cursor](https://cursor.com)