### PR TITLE
ci: gate pull requests on unit, typecheck, lint and Java tests

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,90 @@
+name: test
+
+# Runs the suites that gate a change. Until this workflow existed nothing ran on a pull
+# request, and the only enforcement was the (bypassable) .husky/pre-commit hook.
+#
+# Deliberately NOT gated here:
+#   - the @routr/ctl suite      -> its one test fails on oclif command discovery when run
+#                                  from the monorepo root ("command acl:get not found"),
+#                                  and the root glob below never matched it anyway
+#   - npm run test:integration  -> needs a live Redis
+#   - npm run test:graaljs      -> needs a GraalVM JAVA_HOME plus the jars from npm run setup
+#   - the SEET compliance suite -> needs the full compose stack; see release.yaml
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+# A newer push to the same branch makes an in-flight run obsolete.
+concurrency:
+  group: test-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  unit:
+    name: Unit tests, typecheck and lint
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22.x"
+          cache: npm
+
+      # npm ci, not npm install: the tree must match package-lock.json exactly. An
+      # npm install here silently drifts @oclif/core past the pinned 1.26.2, which
+      # breaks the @routr/ctl build with ~119 type errors.
+      - name: Install dependencies
+        run: npm ci
+
+      # The workspaces resolve to dist/ (@routr/common's main is dist/index) and there
+      # are no tsconfig path mappings back to src, so the suite needs a build first.
+      - name: Generate Prisma client
+        run: npm run generate --workspace=@routr/pgdata
+
+      - name: Build workspaces
+        run: npx lerna run build
+
+      - name: Unit tests
+        run: npm test
+
+      - name: Typecheck
+        run: npm run typecheck
+
+      # The lint script carries --fix, which mutates the tree; CI must only report.
+      - name: Lint
+        run: npx eslint mods --ext .ts
+
+  java:
+    name: EdgePort and Requester tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      # Pinned to 17 on purpose: Mockito 5.1.1 cannot read Java 21 class files, and on a
+      # 21 JDK 20 of the 55 tests fail with ByteBuddy IllegalArgumentException rather
+      # than any real assertion failure.
+      - name: Set up JDK
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "17"
+          cache: gradle
+
+      - name: Java tests
+        run: ./gradlew test
+
+      - name: Upload test report on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: java-test-report
+          path: mods/*/build/reports/tests/test


### PR DESCRIPTION
## Summary

None of routr's six workflows had a `pull_request` trigger, so `npm test` (146 tests), `./gradlew test` (55 tests), `typecheck`, and `lint` **never ran in CI**. The only enforcement was `.husky/pre-commit`, which any contributor can skip with `--no-verify`.

This adds `.github/workflows/test.yaml` with two parallel jobs:

- **unit** — `npm ci`, prisma generate, `lerna run build`, `npm test`, `typecheck`, `eslint`
- **java** — `./gradlew test` on JDK 17, uploading the HTML report on failure

Notably this retroactively protects #360, which already ships `TransactionManagerTest.java` and the `REGRESSION: a peer-to-pstn CANCEL with no X-Dod-Number is not rejected` test — neither of which gated anything until now.

## Two findings worth recording

**The Java job pins JDK 17 deliberately.** Mockito 5.1.1 cannot read Java 21 class files. On a 21 JDK, 20 of the 55 tests fail with a ByteBuddy `IllegalArgumentException` that looks like real assertion failures but is not. Anyone developing on JDK 21 sees this today.

**The install step is `npm ci`, not `npm install`.** An `npm install` drifts `@oclif/core` past the lockfile's pinned `1.26.2` up to `4.x`, where `CliUx` no longer exists and `args` changed shape. That breaks the `@routr/ctl` build with ~119 type errors and makes the entire tree look broken. Worth knowing if you hit it locally: `npm ci` restores it.

## Not gated (yet)

| Suite | Why |
| :--- | :--- |
| `@routr/ctl` tests | Its one test fails on oclif command discovery from the monorepo root (`command acl:get not found`); the root glob never matched it anyway |
| `test:integration` | Needs a live Redis |
| `test:graaljs` | Needs a GraalVM `JAVA_HOME` plus jars from `npm run setup` |
| SEET compliance | Needs the full compose stack; still manual via `release.yaml` |

## Test plan

- [x] `npm ci && npm run generate --workspace=@routr/pgdata && npx lerna run build` — clean
- [x] `npm test` — 146 passing, 4 pending
- [x] `npm run typecheck` — 0 errors
- [x] `npx eslint mods --ext .ts` — 0 errors, 10 warnings
- [x] `./gradlew test` on JDK 17 — BUILD SUCCESSFUL
- [ ] This PR's own run is the real verification

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QoQA8gdo3GEHp2Q2ndQCwx