### PR TITLE
fix(edgeport): send CANCEL with the CSeq of the INVITE it cancels

### DIFF
--- a/etc/scenarios/rr/uas_proxy_auth_caller_cancel.xml
+++ b/etc/scenarios/rr/uas_proxy_auth_caller_cancel.xml
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<!DOCTYPE scenario SYSTEM "sipp.dtd">
+
+<!--
+  Provider that challenges the INVITE, forcing routr to re-authenticate on the caller's
+  behalf, and then receives a CANCEL for the still-ringing call.
+
+  The retry shifts CSeq on this leg only, so the CANCEL routr sends must carry the same
+  shifted number as the INVITE it cancels (RFC 3261 section 9.1) - "3 CANCEL" here, not
+  the caller's "2". Sending the caller's number earns a 481 and the call keeps ringing.
+-->
+<scenario name="RR.Tst.Plan.1.1.5.UAS">
+
+  <recv request="INVITE" />
+
+  <send>
+    <![CDATA[
+      SIP/2.0 401 Unauthorized
+      [last_Via:]
+      [last_From:]
+      [last_To:]
+      [last_Call-ID:]
+      [last_CSeq:]
+      [last_Record-Route:]
+      Contact: <sip:sipp@[local_ip]:[local_port];transport=[transport]>
+      Content-Length: 0
+      Server: SIP Gateway
+      WWW-Authenticate: Digest realm="provider", nonce="d6b6b6b6", algorithm=MD5
+    ]]>
+  </send>
+
+  <recv request="ACK" />
+
+  <!-- routr's authenticated retry: CSeq on this leg is already "3" here, not "2" - the
+       leg's CSeq counter starts ahead of the caller's own numbering, and this provider's
+       401 challenge consumes the retry. Asserted here too (not just on the CANCEL below)
+       because SIPp 3.15.0-alpha in the seet:1.2.0 image aborts at scenario load with
+       "assign_to value is missing" / "Variable $1 is referenced 1 times!" when an
+       assign_to variable is used only once in the file - two uses satisfy it, and this
+       one documents the shift as it happens. -->
+  <recv request="INVITE">
+    <action>
+      <ereg regexp="3 INVITE" search_in="hdr" header="CSeq" case_indep="true" check_it="true" assign_to="1" />
+    </action>
+  </recv>
+
+  <send>
+    <![CDATA[
+      SIP/2.0 180 Ringing
+      [last_Via:]
+      [last_From:]
+      [last_To:]
+      [last_Call-ID:]
+      [last_CSeq:]
+      [last_Record-Route:]
+      Contact: <sip:sipp@[local_ip]:[local_port];transport=[transport]>
+      Content-Length: 0
+    ]]>
+  </send>
+
+  <recv request="CANCEL">
+    <action>
+      <ereg regexp="3 CANCEL" search_in="hdr" header="CSeq" case_indep="true" check_it="true" assign_to="1" />
+    </action>
+  </recv>
+
+  <send>
+    <![CDATA[
+      SIP/2.0 200 OK
+      [last_Via:]
+      [last_From:]
+      [last_To:][peer_tag_param]
+      [last_Call-ID:]
+      [last_CSeq:]
+      [last_Record-Route:]
+      Contact: <sip:sipp@[local_ip]:[local_port];transport=[transport]>
+      Content-Length: 0
+    ]]>
+  </send>
+
+</scenario>

--- a/etc/seet.json
+++ b/etc/seet.json
@@ -478,6 +478,48 @@
     ]
   },
   {
+    "name": "RR.Tst.Plan.1.1.5: Verification of CANCEL CSeq when Proxy authenticates on behalf of caller",
+    "description": "This test case verifies that the CSeq in the CANCEL matches the CSeq in the INVITE it cancels when the Proxy has re-authenticated on the caller's behalf.",
+    "transportMode": "u1",
+    "target": "sip01.edgeport.net:5060",
+    "domain": "sip.local",
+    "userAgents": [
+      {
+        "mode": "uas",
+        "scenarioFile": "scenarios/rr/uas_proxy_auth_caller_cancel.xml",
+        "port": 7060,
+        "sendRegister": true,
+        "expires": 60,
+        "authentication": {
+          "username": "1001",
+          "secret": "1234"
+        }
+      },
+      {
+        "mode": "uac",
+        "scenarioFile": "scenarios/rr/uac_invite_caller_cancel.xml",
+        "authentication": {
+          "username": "1001",
+          "secret": "1234"
+        },
+        "variables": [
+          {
+            "name": "requestURI",
+            "value": "sip:17853178070@sip.local"
+          },
+          {
+            "name": "from",
+            "value": "sip:1001@sip.local"
+          },
+          {
+            "name": "to",
+            "value": "sip:17853178070@sip.local"
+          }
+        ]
+      }
+    ]
+  },
+  {
     "name": "RR.Tst.Plan.1.2.1: Call Declined by Service Provider in Agent to PSTN routing",
     "description": "This test verifies that Routr correctly routes a declined response from the Service Provider",
     "transportMode": "u1",

--- a/mods/edgeport/src/main/java/io/routr/GRPCSipListener.java
+++ b/mods/edgeport/src/main/java/io/routr/GRPCSipListener.java
@@ -564,8 +564,20 @@ public class GRPCSipListener implements SipListener {
   private void sendCancel(final ServerTransaction serverTransaction, final Request request) {
     try {
       var callId = (CallIdHeader) request.getHeader(CallIdHeader.NAME);
+      if (callId == null) {
+        return;
+      }
+
       var originalClientTransaction = transactionManager.getClientTransaction(callId.getCallId());
       var originalServerTransaction = transactionManager.getServerTransaction(callId.getCallId());
+
+      // A CANCEL for a call we no longer hold: unknown Call-ID, or one racing the final
+      // response that freed these slots. Dereferencing them here would throw an NPE,
+      // which the catch below does not cover, onto the JAIN-SIP stack thread.
+      if (originalClientTransaction == null || originalServerTransaction == null) {
+        LOG.debug("no transaction to cancel for callId: {}", callId);
+        return;
+      }
 
       // Check if this is a WebSocket/WSS connection to prevent recursive loop
       boolean isWebSocket = TransportDetector.isWebSocketTransport(request);
@@ -577,14 +589,11 @@ public class GRPCSipListener implements SipListener {
 
       SipMessageSender.sendResponse(serverTransaction, cancelResponse, isWebSocket);
 
-      // Send CANCEL request to destination
-      var cseq = ((CSeqHeader) originalServerTransaction.getRequest().getHeader(CSeqHeader.NAME)).getSeqNumber();
-      var cseqHeader = this.headerFactory.createCSeqHeader(
-          cseq,
-          Request.CANCEL);
-
+      // Send CANCEL request to destination. createCancel copies CSeq from the INVITE on
+      // this leg, which is what RFC 3261 section 9.1 requires them to match on. Do not
+      // overwrite it with the caller's number: a proxy-auth retry shifts this leg past
+      // the caller's numbering, and the far end answers 481 to a CANCEL that disagrees.
       var cancelRequest = originalClientTransaction.createCancel();
-      cancelRequest.setHeader(cseqHeader);
       var clientTransaction = this.sipProvider.getNewClientTransaction(
           cancelRequest);
 


### PR DESCRIPTION
## Summary

Two defects in `GRPCSipListener.sendCancel`, both surfaced by a code review of #360 and both verified here.

**1. The CANCEL's CSeq was overwritten with the wrong number.** `createCancel()` already copies CSeq from the INVITE on the downstream leg, which is exactly what RFC 3261 §9.1 requires a CANCEL to match. The next line replaced it with the caller's number, read from the server transaction. Those two agree right up until a proxy-auth retry shifts the downstream leg past the caller's numbering.

Instrumenting a challenged call made it unambiguous:

```
downstreamInviteCSeq=3   createCancelCSeq=3   overwritingWith=2
```

So on any proxy-authenticated call, routr cancelled INVITE `3` by sending a CANCEL for `2`.

**2. Three unchecked dereferences whose NPE escapes the catch.** `catch (SipException | InvalidArgumentException | ParseException)` covers none of `callId.getCallId()`, `originalServerTransaction.getRequest()`, or `originalClientTransaction.createCancel()`. A CANCEL for an unknown Call-ID, or one racing the final response that frees those slots, threw onto the JAIN-SIP stack thread. #360 routes peer-to-PSTN CANCELs through this method for the first time, so the path is newly reachable from the network.

## Why nothing caught this

No scenario combined proxy-auth with a CANCEL. `RR.Tst.Plan.1.1.3` cancels an agent-to-agent call, where the offset is zero and the overwrite is a no-op. This PR adds `RR.Tst.Plan.1.1.5`, pairing a provider that challenges the INVITE with a caller that cancels, asserting the CSeq on both the retried INVITE and the CANCEL.

## Test plan

- [x] `./gradlew test` on JDK 17 — green (Mockito 5.1.1 cannot read Java 21 bytecode; a 21 JDK gives 20 spurious failures)
- [x] `RR.Tst.Plan.1.1.5` green 3/3 consecutive runs against the compose stack
- [x] Same scenario **red** against the unfixed code, so it is a real regression test rather than one that has only ever been green
- [ ] CI here is the authoritative run: local verification is on Apple Silicon with the SEET container emulated

## Caveats, stated plainly

- The red run failed by timing out rather than by tripping the CSeq assertion, and the pre-registration scenario (independently flaky on this box) failed alongside it. The signal that 1.1.5 is red pre-fix and green post-fix holds, but I could not isolate the exact pre-fix failure mechanism from the EdgePort logs, so I am not claiming one.
- Worth knowing for anyone else authoring SEET scenarios: this image's SIPp (`v3.15.0~alpha`) aborts at scenario **load** time, exit 255 with no traffic at all, when an `ereg`'s `assign_to` variable is referenced only once in the file. Every pre-existing scenario happens to use it at least twice. That cost a while to find and looked exactly like harness flakiness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QoQA8gdo3GEHp2Q2ndQCwx