### PR TITLE
ci: run SEET compliance on PRs; fix RR.Tst.Plan.1.3.2

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -99,18 +99,39 @@ jobs:
   compliance:
     name: SIP Connect v1.1 compliance (SEET)
     runs-on: ubuntu-latest
-    # The suite itself runs ~8 min; the rest is the compose build. Keep some headroom
-    # over release.yaml's 20 so a slow runner reports the SEET failure rather than a
-    # bare timeout.
-    timeout-minutes: 30
+    # npm run make ~5 min + compose build ~6 min + settle + the suite itself ~8 min.
+    # Headroom over that so a slow runner reports the SEET failure, not a bare timeout.
+    timeout-minutes: 45
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
-      # Same sequence release.yaml uses: build every image from the local context
-      # (compose.dev.yaml overrides each service with a build:) so the run tests this
-      # commit, bring the stack up, give edgeport's JVM and the data services time to
-      # settle, then run the compliance container on its own and take its exit code.
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22.x"
+          cache: npm
+
+      # gradle build copyRuntimeLibs (run by npm run setup) needs a JDK. Pinned to 17
+      # for the same reason the java job is.
+      - name: Set up JDK
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "17"
+          cache: gradle
+
+      # compose.dev.yaml builds edgeport/requester from mods/*/libs, which are
+      # .gitignored and produced by the gradle side of the build. Without this the
+      # compose build fails at `COPY mods/edgeport/libs` with "not found". Same step
+      # release.yaml runs before its compliance step.
+      - name: Build project
+        run: npm run make
+
+      # Build every image from the local context (compose.dev.yaml overrides each
+      # service with a build:) so the run tests this commit, bring the stack up, give
+      # edgeport's JVM and the data services time to settle, then run the compliance
+      # container on its own and take its exit code.
       - name: Bring up the stack
         run: |
           docker compose -f compose.yaml -f compose.dev.yaml up --build -d

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -9,13 +9,20 @@ name: test
 #                                  and the root glob below never matched it anyway
 #   - npm run test:integration  -> needs a live Redis
 #   - npm run test:graaljs      -> needs a GraalVM JAVA_HOME plus the jars from npm run setup
-#   - the SEET compliance suite -> needs the full compose stack; see release.yaml
+#
+# The SEET compliance suite runs in the `compliance` job below. It stands up the full
+# compose stack and drives it with SIPp, so it is slower and heavier than the other
+# jobs; it used to run only at release time (release.yaml), which meant a routing or
+# CSeq regression was not caught until a release was already half-published.
 
 on:
   pull_request:
   push:
     branches:
       - main
+  # Lets a branch's compliance run be kicked off (or re-run) by hand, e.g.
+  #   gh workflow run test.yaml --ref <branch>
+  workflow_dispatch:
 
 # A newer push to the same branch makes an in-flight run obsolete.
 concurrency:
@@ -88,3 +95,63 @@ jobs:
         with:
           name: java-test-report
           path: mods/*/build/reports/tests/test
+
+  compliance:
+    name: SIP Connect v1.1 compliance (SEET)
+    runs-on: ubuntu-latest
+    # The suite itself runs ~8 min; the rest is the compose build. Keep some headroom
+    # over release.yaml's 20 so a slow runner reports the SEET failure rather than a
+    # bare timeout.
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      # Same sequence release.yaml uses: build every image from the local context
+      # (compose.dev.yaml overrides each service with a build:) so the run tests this
+      # commit, bring the stack up, give edgeport's JVM and the data services time to
+      # settle, then run the compliance container on its own and take its exit code.
+      - name: Bring up the stack
+        run: |
+          docker compose -f compose.yaml -f compose.dev.yaml up --build -d
+          sleep 60
+          docker compose -f compose.yaml -f compose.dev.yaml ps
+
+      - name: Run the compliance suite
+        run: >
+          docker compose -f compose.yaml -f compose.dev.yaml up
+          --abort-on-container-exit --exit-code-from compliance compliance
+
+      # SEET only prints "UAS failed. See logs for more details" on a failure; the SIPp
+      # message/error traces it means are written to / inside the compliance container,
+      # which has exited but not been removed. Pull them out so a failing run can be
+      # diagnosed from the artifact instead of a local repro (SIP timing does not
+      # survive running the amd64 stack under emulation on a dev machine).
+      - name: Collect SIPp traces
+        if: failure()
+        run: |
+          mkdir -p compliance-traces/rootfs
+          cid=$(docker compose -f compose.yaml -f compose.dev.yaml ps -aq compliance)
+          docker cp "$cid:/." compliance-traces/rootfs/ 2>/dev/null || true
+          find compliance-traces/rootfs -maxdepth 1 \
+            \( -name '*_messages.log' -o -name '*_errors.log' \) \
+            -exec mv {} compliance-traces/ \; 2>/dev/null || true
+          rm -rf compliance-traces/rootfs
+          ls -l compliance-traces || true
+          docker compose -f compose.yaml -f compose.dev.yaml logs --no-color --tail 400 \
+            > compliance-traces/compose-services.log 2>&1 || true
+
+      - name: Upload compliance traces
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: compliance-traces
+          path: |
+            compliance-traces/*_messages.log
+            compliance-traces/*_errors.log
+            compliance-traces/compose-services.log
+          if-no-files-found: warn
+
+      - name: Tear down the stack
+        if: always()
+        run: docker compose -f compose.yaml -f compose.dev.yaml down -v

--- a/etc/scenarios/rr/uas_peer_invite_with_dod_number.xml
+++ b/etc/scenarios/rr/uas_peer_invite_with_dod_number.xml
@@ -41,9 +41,16 @@
     ]]>
   </send>
 
+  <!-- The caller's authenticated INVITE goes out downstream as "2 INVITE" and is not
+       challenged again on this leg, so its ACK is "2 ACK" (RFC 3261 section 13.2.2.4:
+       the ACK for a 2xx carries the INVITE's CSeq). This asserted "3 ACK" until routr
+       2.15.1: edgeport used to add a blind +1 to any forwarded ACK whose transaction
+       carried gateway credentials, whether or not a 401 ever came back. That was fixed
+       to key the offset off an actual challenge (RR.Tst.Plan.1.1.1 / 1.1.5 cover the
+       case where the offset does apply). -->
   <recv request="ACK">
     <action>
-      <ereg regexp="3 ACK" search_in="hdr" header="CSeq" case_indep="true" check_it="true" assign_to="1" />
+      <ereg regexp="2 ACK" search_in="hdr" header="CSeq" case_indep="true" check_it="true" assign_to="1" />
     </action>
   </recv>
 


### PR DESCRIPTION
## Why

The `release` run for v2.15.1 failed on `RR.Tst.Plan.1.3.2` **after** npm publish and the draft release had already happened. Two problems:

1. The SEET compliance suite only ran in `release.yaml` on a manual `workflow_dispatch`, so a routing / CSeq regression could not be caught on the PR that introduced it.
2. `RR.Tst.Plan.1.3.2`'s UAS leg asserted a stale CSeq that #360 legitimately changed.

## What

**`ci: run the SEET compliance suite on pull requests`**
- New `compliance` job in `test.yaml` (runs on `pull_request` and `main` push, parallel with `unit` / `java`). Brings up the compose stack and runs the suite exactly as `release.yaml` does.
- On failure it pulls the SIPp `*_messages.log` / `*_errors.log` out of the `compliance` container and uploads them as an artifact. SEET only prints `UAS failed. See logs for more details`; those traces never left the container before.
- Adds a `workflow_dispatch` trigger so a branch's run can be started by hand.

**`test(compliance): expect 2 ACK downstream in RR.Tst.Plan.1.3.2`**
- The UAS leg pinned the forwarded ACK at `3 ACK`. That `3` only existed because edgeport used to add a blind `+1` to any forwarded ACK whose transaction carried gateway credentials, whether or not the downstream had actually challenged.
- #360 replaced that with an offset keyed off a real 401/407 (`TransactionManager#recordAuthenticated`). In this scenario the provider never challenges, so the caller's authenticated INVITE is forwarded as `2 INVITE` and its ACK is `2 ACK` — per RFC 3261 §13.2.2.4. The path where the offset *does* apply is covered by `RR.Tst.Plan.1.1.1` and `1.1.5`.

## Verification

The `compliance` job on this PR is the check — expect `21 passing` (was 20 + 1 failing). If `2 ACK` is somehow wrong, the `compliance-traces` artifact shows the real downstream CSeq.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YJYgRJAALQQbopPqvHFGZM